### PR TITLE
add custom doc structure to allow for more lax semantics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lnx"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Harrison Burt <57491488+ChillFish8@users.noreply.github.com>"]
 edition = "2018"
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Harrison Burt <57491488+ChillFish8@users.noreply.github.com>"]
 edition = "2018"
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -13,6 +13,7 @@ hashbrown = { version = "0.11", features = ["serde"] }
 uuid = { version = "0.8", features = ["v4", "serde"] }
 symspell = { git = "https://github.com/ChillFish8/symspell", branch = "master" }
 
+chrono = "0.4"
 serde_json = "1"
 num_cpus = "1.13"
 rayon = "1.5"

--- a/engine/build.rs
+++ b/engine/build.rs
@@ -1,6 +1,5 @@
-use std::fs;
 use std::io::Write;
-use std::path;
+use std::{fs, path};
 
 use anyhow::Result;
 use flate2::write::GzEncoder;

--- a/engine/src/correction.rs
+++ b/engine/src/correction.rs
@@ -1,11 +1,10 @@
-use once_cell::sync::OnceCell;
 use std::fs;
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use symspell::{AsciiStringStrategy, SymSpell};
-
 use flate2::write::GzDecoder;
+use once_cell::sync::OnceCell;
+use symspell::{AsciiStringStrategy, SymSpell};
 
 static SYMSPELL: OnceCell<SymSpell<AsciiStringStrategy>> = OnceCell::new();
 static ENABLED: AtomicBool = AtomicBool::new(false);

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -1,6 +1,7 @@
+use std::sync::Arc;
+
 use anyhow::{Error, Result};
 use hashbrown::HashMap;
-use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::correction::enable_load_dictionaries;

--- a/engine/src/helpers.rs
+++ b/engine/src/helpers.rs
@@ -4,7 +4,7 @@ use ahash::AHasher;
 
 use crate::correction::correct_sentence;
 use crate::structures;
-use crate::structures::DocumentValue;
+use crate::structures::{DocumentValue, DocumentItem};
 
 pub(crate) fn hash<T: Hash>(v: &T) -> u64 {
     let mut hasher = AHasher::default();
@@ -20,12 +20,27 @@ pub fn correct_doc_fields(doc: &mut structures::Document, indexed_text_fields: &
 
         let maybe_values = doc.0.get(target);
         if let Some(values) = maybe_values {
-            for val in values {
-                if let DocumentValue::Text(data) = val {
-                    let corrected = correct_sentence(data, 1);
-                    changes.push((format!("_{}", id), vec![DocumentValue::Text(corrected)]));
+            match values {
+                DocumentItem::Single(value) =>  {
+                    if let DocumentValue::Text(ref data) = value {
+                        let corrected = correct_sentence(data, 1);
+                        changes.push((format!("_{}", id), DocumentItem::Single(DocumentValue::Text(corrected))));
+                    }
+                },
+                DocumentItem::Multi(values) => {
+                    let mut local_changes = vec![];
+                    for val in values {
+                        if let DocumentValue::Text(ref data) = val {
+                            let corrected = correct_sentence(data, 1);
+                            local_changes.push(DocumentValue::Text(corrected));
+                        }
+                    }
+                    if local_changes.len() > 0 {
+                        changes.push((format!("_{}", id), DocumentItem::Multi(local_changes)));
+                    }
                 }
             }
+
         };
     }
 

--- a/engine/src/helpers.rs
+++ b/engine/src/helpers.rs
@@ -1,5 +1,6 @@
-use ahash::AHasher;
 use std::hash::{Hash, Hasher};
+
+use ahash::AHasher;
 
 use crate::correction::correct_sentence;
 use crate::structures;

--- a/engine/src/helpers.rs
+++ b/engine/src/helpers.rs
@@ -1,9 +1,9 @@
 use ahash::AHasher;
 use std::hash::{Hash, Hasher};
 
-use tantivy::schema::{NamedFieldDocument, Value};
-
 use crate::correction::correct_sentence;
+use crate::structures;
+use crate::structures::DocumentValue;
 
 pub(crate) fn hash<T: Hash>(v: &T) -> u64 {
     let mut hasher = AHasher::default();
@@ -11,7 +11,7 @@ pub(crate) fn hash<T: Hash>(v: &T) -> u64 {
     hasher.finish()
 }
 
-pub fn correct_doc_fields(doc: &mut NamedFieldDocument, indexed_text_fields: &Vec<String>) {
+pub fn correct_doc_fields(doc: &mut structures::Document, indexed_text_fields: &Vec<String>) {
     let mut changes = vec![];
 
     for target in indexed_text_fields {
@@ -20,9 +20,9 @@ pub fn correct_doc_fields(doc: &mut NamedFieldDocument, indexed_text_fields: &Ve
         let maybe_values = doc.0.get(target);
         if let Some(values) = maybe_values {
             for val in values {
-                if let Value::Str(data) = val {
+                if let DocumentValue::Text(data) = val {
                     let corrected = correct_sentence(data, 1);
-                    changes.push((format!("_{}", id), vec![Value::Str(corrected)]));
+                    changes.push((format!("_{}", id), vec![DocumentValue::Text(corrected)]));
                 }
             }
         };

--- a/engine/src/index/mod.rs
+++ b/engine/src/index/mod.rs
@@ -1,13 +1,13 @@
+use std::sync::Arc;
+
 use anyhow::{Error, Result};
 use parking_lot::Mutex;
-use std::sync::Arc;
-use tokio::fs;
-use tokio::task::JoinHandle;
-
 use tantivy::directory::MmapDirectory;
 use tantivy::query::QueryParser;
 use tantivy::schema::{Schema, Value};
 use tantivy::{Document, Index, IndexBuilder, ReloadPolicy, Term};
+use tokio::fs;
+use tokio::task::JoinHandle;
 
 use crate::correction;
 use crate::helpers::{self, hash};
@@ -104,11 +104,11 @@ impl IndexHandler {
                     &loader.name
                 );
                 (index.create_from_tempdir()?, None)
-            }
+            },
             IndexStorageType::Memory => {
                 info!("[ SETUP @ {} ] creating index in memory", &loader.name);
                 (index.create_in_ram()?, None)
-            }
+            },
             IndexStorageType::FileSystem => {
                 info!("[ SETUP @ {} ] creating index in directory", &loader.name);
 
@@ -117,7 +117,7 @@ impl IndexHandler {
 
                 let dir = MmapDirectory::open(&path)?;
                 (index.open_or_create(dir)?, Some(path.clone()))
-            }
+            },
         };
 
         Ok(out)
@@ -159,7 +159,7 @@ impl IndexHandler {
                     } else {
                         search_fields.push((field, 0.0f32));
                     };
-                }
+                },
                 (Some(field), None) => {
                     if let Some(boost) = loader.boost_fields.get(&ref_field) {
                         debug!("boosting field for query parser {} {}", &ref_field, boost);
@@ -167,7 +167,7 @@ impl IndexHandler {
                     } else {
                         search_fields.push((field, 0.0f32));
                     };
-                }
+                },
                 (None, _) => {
                     let fields: Vec<String> = loader
                         .schema
@@ -180,7 +180,7 @@ impl IndexHandler {
                         and declared the a search_field {:?} but this does not exist in the defined fields.",
                         fields, &ref_field
                     )));
-                }
+                },
             };
         }
 

--- a/engine/src/index/writer.rs
+++ b/engine/src/index/writer.rs
@@ -1,13 +1,10 @@
 use std::sync::Arc;
 
 use anyhow::{Error, Result};
-
-use tokio::sync::oneshot;
-
 use crossbeam::channel;
 use crossbeam::queue::SegQueue;
-
 use tantivy::{Document, IndexWriter, Term};
+use tokio::sync::oneshot;
 
 /// A writing operation to be sent to the `IndexWriterWorker`.
 #[derive(Debug)]
@@ -85,7 +82,7 @@ impl IndexWriterWorker {
                     &self.index_name, e,
                 ),
                 Ok(true) => return true,
-                _ => {}
+                _ => {},
             }
         }
 
@@ -173,7 +170,7 @@ impl IndexWriterHandler {
                 Ok(()) => return Ok(()),
                 Err(channel::TrySendError::Disconnected(_)) => {
                     return Err(Error::msg("writer worker has shutdown"))
-                }
+                },
                 Err(channel::TrySendError::Full(v)) => v,
             };
 

--- a/engine/src/stop_words.rs
+++ b/engine/src/stop_words.rs
@@ -1,8 +1,9 @@
+use std::io::Write;
+
 use anyhow::{Error, Result};
 use flate2::write::GzDecoder;
 use hashbrown::HashSet;
 use once_cell::sync::OnceCell;
-use std::io::Write;
 
 static STOP_WORDS: OnceCell<Vec<String>> = OnceCell::new();
 static STOP_WORDS_HASHSET: OnceCell<HashSet<String>> = OnceCell::new();

--- a/engine/src/structures.rs
+++ b/engine/src/structures.rs
@@ -1,12 +1,18 @@
 use hashbrown::HashMap;
-use serde::{Deserialize, Serialize};
+use anyhow::{Result, Error};
+use core::fmt;
+
+use serde::{Deserialize, Serialize, Deserializer};
+use serde::de::Visitor;
+
+use std::str::FromStr;
+use std::collections::BTreeMap;
+
+use tantivy::schema::{Cardinality, Field, IntOptions, Schema as InternalSchema, SchemaBuilder as InternalSchemaBuilder, Document as InternalDocument, STORED, STRING, TEXT, FieldType};
+use tantivy::{DateTime, Score};
+use tantivy::fastfield::FastValue;
 
 use crate::helpers::hash;
-use tantivy::schema::{
-    Cardinality, Field, IntOptions, Schema as InternalSchema,
-    SchemaBuilder as InternalSchemaBuilder, STORED, STRING, TEXT,
-};
-use tantivy::{DateTime, Score};
 
 /// A declared schema field type.
 ///
@@ -309,6 +315,103 @@ pub enum FieldValue {
     /// A text field.
     Text(Vec<String>),
 }
+
+#[derive(Debug, Deserialize)]
+pub struct Document(pub BTreeMap<String, Vec<DocumentValue>>);
+
+/// A document that can be processed by tantivy.
+#[derive(Debug)]
+pub enum DocumentValue {
+    /// A signed 64 bit integer.
+    I64(i64),
+
+    /// A 64 bit floating point number.
+    F64(f64),
+
+    /// A unsigned 64 bit integer.
+    U64(u64),
+
+    /// A datetime field, deserialized as a u64 int.
+    Datetime(DateTime),
+
+    /// A text field.
+    Text(String),
+}
+
+impl<'de> Deserialize<'de> for DocumentValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ValueVisitor;
+
+        impl<'de> Visitor<'de> for ValueVisitor {
+            type Value = DocumentValue;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a string or u32")
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> {
+                Ok(DocumentValue::I64(v))
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> {
+                Ok(DocumentValue::U64(v))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E> {
+                Ok(DocumentValue::F64(v))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> {
+                if let Ok(dt) = tantivy::DateTime::from_str(&v) {
+                    return Ok(DocumentValue::Datetime(dt))
+                }
+
+                Ok(DocumentValue::Text(v.to_owned()))
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> {
+                if let Ok(dt) = tantivy::DateTime::from_str(&v) {
+                    return Ok(DocumentValue::Datetime(dt))
+                }
+                Ok(DocumentValue::Text(v))
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
+    }
+}
+
+impl Document {
+    pub(crate) fn parse_into_document(self, schema: &InternalSchema) -> Result<InternalDocument> {
+        let mut doc = InternalDocument::new();
+        for (key, values) in self.0 {
+            let field = schema.get_field(&key)
+                .ok_or_else(|| Error::msg(format!("field {:?} does not exist in schema", &key)))?;
+
+            let entry = schema.get_field_entry(field);
+            let field_type = entry.field_type();
+
+            for value in values {
+                match (value, field_type) {
+                    (DocumentValue::I64(v), FieldType::I64(_)) => doc.add_i64(field, v),
+                    (DocumentValue::U64(v), FieldType::U64(_)) => doc.add_u64(field, v),
+                    (DocumentValue::F64(v), FieldType::F64(_)) => doc.add_f64(field, v),
+                    (DocumentValue::Text(v), FieldType::Str(_)) => doc.add_text(field, v),
+                    (DocumentValue::Datetime(v), FieldType::Str(_)) => doc.add_text(field, v.to_string()),
+                    (DocumentValue::Datetime(v), FieldType::Date(_)) => doc.add_date(field, &v),
+                    (DocumentValue::U64(v), FieldType::Date(_)) => doc.add_date(field, &DateTime::from_u64(v)),
+                    _ => return Err(Error::msg(format!("filed {:?} is type {:?} in schema but did not get a valid value", &key, field_type)))
+                }
+            }
+        }
+
+        Ok(doc)
+    }
+}
+
 
 mod deserialize_datetime {
     use serde::{Deserialize, Deserializer};

--- a/engine/src/structures.rs
+++ b/engine/src/structures.rs
@@ -299,48 +299,6 @@ mod default_query_data {
     }
 }
 
-/// A set of values that can be used to extract a `Term`.
-///
-/// This system is designed to handle JSON based deserialization
-/// so Bytes and datetime are handled as base64 encoded strings and u64 timestamps
-/// respectively.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
-#[serde(tag = "type", content = "value")]
-pub enum FieldValue {
-    /// A signed 64 bit integer.
-    I64(Vec<i64>),
-
-    /// A 64 bit floating point number.
-    F64(Vec<f64>),
-
-    /// A unsigned 64 bit integer.
-    U64(Vec<u64>),
-
-    /// A datetime field, deserialized as a u64 int.
-    #[serde(with = "deserialize_datetime")]
-    Datetime(Vec<DateTime>),
-
-    /// A text field.
-    Text(Vec<String>),
-}
-
-mod deserialize_datetime {
-    use serde::{Deserialize, Deserializer};
-    use tantivy::fastfield::FastValue;
-    use tantivy::DateTime;
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<DateTime>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let multi = Vec::<u64>::deserialize(deserializer)?;
-        let values: Vec<DateTime> = multi.iter().map(|v| DateTime::from_u64(*v)).collect();
-
-        Ok(values)
-    }
-}
-
 /// A tantivy document representation.
 ///
 /// This is checked against the schema and validated before being

--- a/engine/src/structures.rs
+++ b/engine/src/structures.rs
@@ -1,21 +1,27 @@
-use anyhow::{Error, Result};
 use core::fmt;
-use hashbrown::HashMap;
-
-use serde::de::Visitor;
-use serde::{Deserialize, Deserializer, Serialize};
-
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
+use anyhow::{Error, Result};
+use chrono::Utc;
+use hashbrown::HashMap;
+use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize};
 use tantivy::schema::{
-    Cardinality, Document as InternalDocument, Field, FieldType, IntOptions,
-    Schema as InternalSchema, SchemaBuilder as InternalSchemaBuilder, STORED, STRING, TEXT,
+    Cardinality,
+    Document as InternalDocument,
+    Field,
+    FieldType,
+    IntOptions,
+    Schema as InternalSchema,
+    SchemaBuilder as InternalSchemaBuilder,
+    STORED,
+    STRING,
+    TEXT,
 };
 use tantivy::{DateTime, Score};
 
 use crate::helpers::hash;
-use chrono::Utc;
 
 /// A declared schema field type.
 ///
@@ -105,16 +111,16 @@ impl IndexDeclaration {
             match field {
                 FieldDeclaration::F64(opts) => {
                     schema.add_f64_field(&name, opts);
-                }
+                },
                 FieldDeclaration::U64(opts) => {
                     schema.add_u64_field(&name, opts);
-                }
+                },
                 FieldDeclaration::I64(opts) => {
                     schema.add_f64_field(&name, opts);
-                }
+                },
                 FieldDeclaration::Date(opts) => {
                     schema.add_date_field(&name, opts);
-                }
+                },
                 FieldDeclaration::String { stored } => {
                     let mut opts = STRING;
 
@@ -122,7 +128,7 @@ impl IndexDeclaration {
                         opts = opts | STORED;
                     }
                     schema.add_text_field(&name, opts);
-                }
+                },
                 FieldDeclaration::Text { stored } => {
                     let field = if !(self.use_fast_fuzzy && crate::correction::enabled()) {
                         let mut opts = TEXT;
@@ -149,7 +155,7 @@ impl IndexDeclaration {
                     };
 
                     fuzzy_search_fields.push((field, boost));
-                }
+                },
             };
         }
 

--- a/engine/src/structures.rs
+++ b/engine/src/structures.rs
@@ -316,10 +316,31 @@ pub enum FieldValue {
     Text(Vec<String>),
 }
 
+mod deserialize_datetime {
+    use serde::{Deserialize, Deserializer};
+    use tantivy::fastfield::FastValue;
+    use tantivy::DateTime;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<DateTime>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let multi = Vec::<u64>::deserialize(deserializer)?;
+        let values: Vec<DateTime> = multi.iter().map(|v| DateTime::from_u64(*v)).collect();
+
+        Ok(values)
+    }
+}
+
+
+/// A tantivy document representation.
+///
+/// This is checked against the schema and validated before being
+/// converted into a direct tantivy type.
 #[derive(Debug, Deserialize)]
 pub struct Document(pub BTreeMap<String, Vec<DocumentValue>>);
 
-/// A document that can be processed by tantivy.
+/// A document value that can be processed by tantivy.
 #[derive(Debug)]
 pub enum DocumentValue {
     /// A signed 64 bit integer.
@@ -432,18 +453,3 @@ impl Document {
 }
 
 
-mod deserialize_datetime {
-    use serde::{Deserialize, Deserializer};
-    use tantivy::fastfield::FastValue;
-    use tantivy::DateTime;
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<DateTime>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let multi = Vec::<u64>::deserialize(deserializer)?;
-        let values: Vec<DateTime> = multi.iter().map(|v| DateTime::from_u64(*v)).collect();
-
-        Ok(values)
-    }
-}

--- a/engine/src/structures.rs
+++ b/engine/src/structures.rs
@@ -1,14 +1,17 @@
-use hashbrown::HashMap;
-use anyhow::{Result, Error};
+use anyhow::{Error, Result};
 use core::fmt;
+use hashbrown::HashMap;
 
-use serde::{Deserialize, Serialize, Deserializer};
 use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize};
 
-use std::str::FromStr;
 use std::collections::BTreeMap;
+use std::str::FromStr;
 
-use tantivy::schema::{Cardinality, Field, IntOptions, Schema as InternalSchema, SchemaBuilder as InternalSchemaBuilder, Document as InternalDocument, STORED, STRING, TEXT, FieldType};
+use tantivy::schema::{
+    Cardinality, Document as InternalDocument, Field, FieldType, IntOptions,
+    Schema as InternalSchema, SchemaBuilder as InternalSchemaBuilder, STORED, STRING, TEXT,
+};
 use tantivy::{DateTime, Score};
 
 use crate::helpers::hash;
@@ -332,7 +335,6 @@ mod deserialize_datetime {
     }
 }
 
-
 /// A tantivy document representation.
 ///
 /// This is checked against the schema and validated before being
@@ -387,7 +389,7 @@ impl<'de> Deserialize<'de> for DocumentValue {
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> {
                 if let Ok(dt) = tantivy::DateTime::from_str(&v) {
-                    return Ok(DocumentValue::Datetime(dt))
+                    return Ok(DocumentValue::Datetime(dt));
                 }
 
                 Ok(DocumentValue::Text(v.to_owned()))
@@ -395,7 +397,7 @@ impl<'de> Deserialize<'de> for DocumentValue {
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> {
                 if let Ok(dt) = tantivy::DateTime::from_str(&v) {
-                    return Ok(DocumentValue::Datetime(dt))
+                    return Ok(DocumentValue::Datetime(dt));
                 }
                 Ok(DocumentValue::Text(v))
             }
@@ -409,7 +411,8 @@ impl Document {
     pub(crate) fn parse_into_document(self, schema: &InternalSchema) -> Result<InternalDocument> {
         let mut doc = InternalDocument::new();
         for (key, values) in self.0 {
-            let field = schema.get_field(&key)
+            let field = schema
+                .get_field(&key)
                 .ok_or_else(|| Error::msg(format!("field {:?} does not exist in schema", &key)))?;
 
             let entry = schema.get_field_entry(field);
@@ -451,5 +454,3 @@ impl Document {
         Ok(doc)
     }
 }
-
-

--- a/engine/src/structures.rs
+++ b/engine/src/structures.rs
@@ -7,13 +7,12 @@ use serde::de::Visitor;
 
 use std::str::FromStr;
 use std::collections::BTreeMap;
-use std::convert::TryFrom;
 
 use tantivy::schema::{Cardinality, Field, IntOptions, Schema as InternalSchema, SchemaBuilder as InternalSchemaBuilder, Document as InternalDocument, STORED, STRING, TEXT, FieldType};
 use tantivy::{DateTime, Score};
-use tantivy::fastfield::FastValue;
 
 use crate::helpers::hash;
+use chrono::Utc;
 
 /// A declared schema field type.
 ///
@@ -405,21 +404,21 @@ impl Document {
                     (DocumentValue::Datetime(v), FieldType::Date(_)) => doc.add_date(field, &v),
                     (DocumentValue::I64(v), FieldType::Date(_)) => {
                         match chrono::NaiveDateTime::from_timestamp_opt(v, 0) {
-                            Ok(v) => {
-                                let dt = chrono::DateTime::from_utc(v, 0);
+                            Some(dt) => {
+                                let dt = chrono::DateTime::from_utc(dt, Utc);
                                 doc.add_date(field, &dt)
                             },
-                            Err(_) =>
+                            None =>
                                 return Err(Error::msg(format!("filed {:?} is type {:?} in schema but did not get a valid value (invalid timestamp)", &key, field_type))),
                         }
                     },
                     (DocumentValue::U64(v), FieldType::Date(_)) => {
                         match chrono::NaiveDateTime::from_timestamp_opt(v as i64, 0) {
-                            Ok(v) => {
-                                let dt = chrono::DateTime::from_utc(v, 0);
+                            Some(dt) => {
+                                let dt = chrono::DateTime::from_utc(dt, Utc);
                                 doc.add_date(field, &dt)
                             },
-                            Err(_) =>
+                            None =>
                                 return Err(Error::msg(format!("filed {:?} is type {:?} in schema but did not get a valid value (invalid timestamp)", &key, field_type))),
                         }
                     },

--- a/engine/src/structures.rs
+++ b/engine/src/structures.rs
@@ -346,7 +346,14 @@ mod deserialize_datetime {
 /// This is checked against the schema and validated before being
 /// converted into a direct tantivy type.
 #[derive(Debug, Deserialize)]
-pub struct Document(pub BTreeMap<String, Vec<DocumentValue>>);
+pub struct Document(pub BTreeMap<String, DocumentItem>);
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum DocumentItem {
+    Single(DocumentValue),
+    Multi(Vec<DocumentValue>)
+}
 
 /// A document value that can be processed by tantivy.
 #[derive(Debug)]
@@ -424,39 +431,51 @@ impl Document {
             let entry = schema.get_field_entry(field);
             let field_type = entry.field_type();
 
-            for value in values {
-                match (value, field_type) {
-                    (DocumentValue::I64(v), FieldType::I64(_)) => doc.add_i64(field, v),
-                    (DocumentValue::U64(v), FieldType::U64(_)) => doc.add_u64(field, v),
-                    (DocumentValue::F64(v), FieldType::F64(_)) => doc.add_f64(field, v),
-                    (DocumentValue::Text(v), FieldType::Str(_)) => doc.add_text(field, v),
-                    (DocumentValue::Datetime(v), FieldType::Str(_)) => doc.add_text(field, v.to_string()),
-                    (DocumentValue::Datetime(v), FieldType::Date(_)) => doc.add_date(field, &v),
-                    (DocumentValue::I64(v), FieldType::Date(_)) => {
-                        match chrono::NaiveDateTime::from_timestamp_opt(v, 0) {
-                            Some(dt) => {
-                                let dt = chrono::DateTime::from_utc(dt, Utc);
-                                doc.add_date(field, &dt)
-                            },
-                            None =>
-                                return Err(Error::msg(format!("filed {:?} is type {:?} in schema but did not get a valid value (invalid timestamp)", &key, field_type))),
-                        }
-                    },
-                    (DocumentValue::U64(v), FieldType::Date(_)) => {
-                        match chrono::NaiveDateTime::from_timestamp_opt(v as i64, 0) {
-                            Some(dt) => {
-                                let dt = chrono::DateTime::from_utc(dt, Utc);
-                                doc.add_date(field, &dt)
-                            },
-                            None =>
-                                return Err(Error::msg(format!("filed {:?} is type {:?} in schema but did not get a valid value (invalid timestamp)", &key, field_type))),
-                        }
-                    },
-                    _ => return Err(Error::msg(format!("filed {:?} is type {:?} in schema but did not get a valid value", &key, field_type)))
-                }
-            }
+            match values {
+                DocumentItem::Single(value) =>
+                    add_value(&key, field, field_type, value, &mut doc)?,
+                DocumentItem::Multi(values) => {
+                    for value in values {
+                        add_value(&key, field, field_type, value, &mut doc)?;
+                    }
+                },
+            };
         }
 
         Ok(doc)
     }
+}
+
+fn add_value(key: &String, field: Field, field_type: &FieldType, value: DocumentValue, doc: &mut InternalDocument) -> Result<()> {
+    match (value, field_type) {
+        (DocumentValue::I64(v), FieldType::I64(_)) => doc.add_i64(field, v),
+        (DocumentValue::U64(v), FieldType::U64(_)) => doc.add_u64(field, v),
+        (DocumentValue::F64(v), FieldType::F64(_)) => doc.add_f64(field, v),
+        (DocumentValue::Text(v), FieldType::Str(_)) => doc.add_text(field, v),
+        (DocumentValue::Datetime(v), FieldType::Str(_)) => doc.add_text(field, v.to_string()),
+        (DocumentValue::Datetime(v), FieldType::Date(_)) => doc.add_date(field, &v),
+        (DocumentValue::I64(v), FieldType::Date(_)) => {
+            match chrono::NaiveDateTime::from_timestamp_opt(v, 0) {
+                Some(dt) => {
+                    let dt = chrono::DateTime::from_utc(dt, Utc);
+                    doc.add_date(field, &dt)
+                },
+                None =>
+                    return Err(Error::msg(format!("filed {:?} is type {:?} in schema but did not get a valid value (invalid timestamp)", &key, field_type))),
+            }
+        },
+        (DocumentValue::U64(v), FieldType::Date(_)) => {
+            match chrono::NaiveDateTime::from_timestamp_opt(v as i64, 0) {
+                Some(dt) => {
+                    let dt = chrono::DateTime::from_utc(dt, Utc);
+                    doc.add_date(field, &dt)
+                },
+                None =>
+                    return Err(Error::msg(format!("filed {:?} is type {:?} in schema but did not get a valid value (invalid timestamp)", &key, field_type))),
+            }
+        },
+        _ => return Err(Error::msg(format!("filed {:?} is type {:?} in schema but did not get a valid value", &key, field_type)))
+    }
+
+    Ok(())
 }

--- a/lnxcli/benchmark/src/lib.rs
+++ b/lnxcli/benchmark/src/lib.rs
@@ -6,12 +6,11 @@ mod meilisearch;
 mod sampler;
 mod shared;
 
-use anyhow::Result;
-
-use rand::seq::SliceRandom;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use anyhow::Result;
+use rand::seq::SliceRandom;
 use serde_json::Value;
 use tokio::fs;
 use tokio::task::JoinHandle;
@@ -121,16 +120,16 @@ async fn start(ctx: Context) -> anyhow::Result<()> {
             match (target, mode) {
                 (BenchTarget::MeiliSearch, BenchMode::Standard) => {
                     meilisearch::bench_standard(addr, sample_handler, temp_terms, index).await
-                }
+                },
                 (BenchTarget::MeiliSearch, BenchMode::Typing) => {
                     meilisearch::bench_typing(addr, sample_handler, temp_terms, index).await
-                }
+                },
                 (BenchTarget::Lnx, BenchMode::Standard) => {
                     lnx::bench_standard(addr, sample_handler, temp_terms, index).await
-                }
+                },
                 (BenchTarget::Lnx, BenchMode::Typing) => {
                     lnx::bench_typing(addr, sample_handler, temp_terms, index).await
-                }
+                },
             }
         });
 

--- a/lnxcli/benchmark/src/lnx.rs
+++ b/lnxcli/benchmark/src/lnx.rs
@@ -1,9 +1,10 @@
-use serde_json::Value;
 use std::sync::Arc;
 use std::time::Instant;
 
+use serde_json::Value;
+
 use crate::sampler::SamplerHandle;
-use crate::shared::{TargetUri, RequestClient, Query};
+use crate::shared::{Query, RequestClient, TargetUri};
 
 pub(crate) async fn prep(address: &str, data: Value, index: &str) -> anyhow::Result<()> {
     let client = reqwest::Client::new();
@@ -43,12 +44,9 @@ pub(crate) async fn bench_standard(
         sample,
         terms,
         &index,
-        move |client, uri, query| {
-            async {
-                search(client, uri, query).await
-            }
-        }
-    ).await
+        move |client, uri, query| async { search(client, uri, query).await },
+    )
+    .await
 }
 
 pub(crate) async fn bench_typing(
@@ -62,12 +60,9 @@ pub(crate) async fn bench_typing(
         sample,
         terms,
         &index,
-        move |client, uri, query| {
-            async {
-                search(client, uri, query).await
-            }
-        }
-    ).await
+        move |client, uri, query| async { search(client, uri, query).await },
+    )
+    .await
 }
 
 async fn search(client: RequestClient, uri: TargetUri, query: Query) -> anyhow::Result<u16> {

--- a/lnxcli/benchmark/src/meilisearch.rs
+++ b/lnxcli/benchmark/src/meilisearch.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use tokio::time::Duration;
 
 use crate::sampler::SamplerHandle;
-use crate::shared::{RequestClient, TargetUri, Query};
+use crate::shared::{Query, RequestClient, TargetUri};
 
 #[derive(Debug, Deserialize)]
 struct EnqueueResponseData {
@@ -100,12 +100,9 @@ pub(crate) async fn bench_standard(
         sample,
         terms,
         &index,
-        move |client, uri, query| {
-            async {
-                search(client, uri, query).await
-            }
-        }
-    ).await
+        move |client, uri, query| async { search(client, uri, query).await },
+    )
+    .await
 }
 
 pub(crate) async fn bench_typing(
@@ -119,12 +116,9 @@ pub(crate) async fn bench_typing(
         sample,
         terms,
         &index,
-        move |client, uri, query| {
-            async {
-                search(client, uri, query).await
-            }
-        }
-    ).await
+        move |client, uri, query| async { search(client, uri, query).await },
+    )
+    .await
 }
 
 #[derive(Serialize)]

--- a/lnxcli/benchmark/src/sampler.rs
+++ b/lnxcli/benchmark/src/sampler.rs
@@ -1,7 +1,7 @@
-use anyhow::Error;
-use plotters::prelude::*;
 use std::collections::HashMap;
 
+use anyhow::Error;
+use plotters::prelude::*;
 use tokio::sync::oneshot;
 use tokio::time::{Duration, Instant};
 

--- a/lnxcli/benchmark/src/shared.rs
+++ b/lnxcli/benchmark/src/shared.rs
@@ -1,16 +1,14 @@
 use std::future::Future;
-use std::time::Instant;
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::Result;
 
 use crate::sampler::SamplerHandle;
 
-
 pub(crate) type RequestClient = reqwest::Client;
 pub(crate) type TargetUri = Arc<String>;
 pub(crate) type Query = String;
-
 
 fn get_client_and_addr(address: Arc<String>, index: &str) -> (RequestClient, TargetUri) {
     let search_addr = Arc::new(format!("{}/indexes/{}/search", address, index));
@@ -19,13 +17,12 @@ fn get_client_and_addr(address: Arc<String>, index: &str) -> (RequestClient, Tar
     (client, search_addr)
 }
 
-
 pub(crate) async fn start_standard<T: Future<Output = Result<u16>>>(
     address: Arc<String>,
     mut sample: SamplerHandle,
     terms: Vec<String>,
     index: &str,
-    callback: fn(RequestClient, TargetUri, Query) -> T
+    callback: fn(RequestClient, TargetUri, Query) -> T,
 ) -> Result<()> {
     let (client, search_addr) = get_client_and_addr(address, index);
     sample.start_timing();
@@ -51,7 +48,7 @@ pub(crate) async fn start_typing<T: Future<Output = Result<u16>>>(
     mut sample: SamplerHandle,
     terms: Vec<String>,
     index: &str,
-    callback: fn(RequestClient, TargetUri, Query) -> T
+    callback: fn(RequestClient, TargetUri, Query) -> T,
 ) -> Result<()> {
     let (client, search_addr) = get_client_and_addr(address, index);
     sample.start_timing();

--- a/lnxcli/demo/src/lib.rs
+++ b/lnxcli/demo/src/lib.rs
@@ -2,10 +2,11 @@
 extern crate log;
 
 use std::net::SocketAddr;
-use axum::Router;
-use axum::handler::{get, post};
-use anyhow::Error;
 use std::time::Instant;
+
+use anyhow::Error;
+use axum::handler::{get, post};
+use axum::Router;
 use hyper::http::StatusCode;
 use tokio::time::Duration;
 
@@ -30,14 +31,17 @@ pub fn run(ctx: Context) -> anyhow::Result<()> {
 
 async fn start(ctx: Context) -> anyhow::Result<()> {
     if !ctx.target_server.starts_with("http") {
-        return Err(Error::msg("target server must include the http protocol."))
+        return Err(Error::msg("target server must include the http protocol."));
     }
 
     if !ctx.no_prep {
         prep(&ctx).await?;
     }
 
-    let _ = routes::TARGET_URL.set(format!("{}/indexes/{}/search", &ctx.target_server, &ctx.index));
+    let _ = routes::TARGET_URL.set(format!(
+        "{}/indexes/{}/search",
+        &ctx.target_server, &ctx.index
+    ));
 
     let app = Router::new()
         .route("/", get(routes::index))
@@ -109,14 +113,19 @@ async fn prep(ctx: &Context) -> anyhow::Result<()> {
         "strip_stop_words": ctx.strip_stop_words,
     });
 
-    let r = client.post(format!("{}/indexes?override_if_exists=true", &ctx.target_server))
+    let r = client
+        .post(format!(
+            "{}/indexes?override_if_exists=true",
+            &ctx.target_server
+        ))
         .json(&payload)
         .send()
         .await?;
 
     if r.status() != StatusCode::OK {
         return Err(Error::msg(
-            "server returned a non 200 OK code when creating index. Check your server logs."))
+            "server returned a non 200 OK code when creating index. Check your server logs.",
+        ));
     }
 
     // let changed propagate
@@ -124,35 +133,47 @@ async fn prep(ctx: &Context) -> anyhow::Result<()> {
 
     // Clear the existing docs
     let r = client
-        .delete(format!("{}/indexes/{}/documents/clear", &ctx.target_server, &ctx.index))
+        .delete(format!(
+            "{}/indexes/{}/documents/clear",
+            &ctx.target_server, &ctx.index
+        ))
         .send()
         .await?;
 
     if r.status() != StatusCode::OK {
         return Err(Error::msg(
-            "server returned a non 200 OK code when clearing docs. Check your server logs."))
+            "server returned a non 200 OK code when clearing docs. Check your server logs.",
+        ));
     }
 
     let start = Instant::now();
     let r = client
-        .post(format!("{}/indexes/{}/documents", &ctx.target_server, &ctx.index))
+        .post(format!(
+            "{}/indexes/{}/documents",
+            &ctx.target_server, &ctx.index
+        ))
         .json(&data)
         .send()
         .await?;
 
     if r.status() != StatusCode::OK {
         return Err(Error::msg(
-            "server returned a non 200 OK code when adding docs. Check your server logs."))
+            "server returned a non 200 OK code when adding docs. Check your server logs.",
+        ));
     }
 
     let r = client
-        .post(format!("{}/indexes/{}/commit", &ctx.target_server, &ctx.index))
+        .post(format!(
+            "{}/indexes/{}/commit",
+            &ctx.target_server, &ctx.index
+        ))
         .send()
         .await?;
 
     if r.status() != StatusCode::OK {
         return Err(Error::msg(
-            "server returned a non 200 OK code when committing changes. Check your server logs."))
+            "server returned a non 200 OK code when committing changes. Check your server logs.",
+        ));
     }
 
     let delta = start.elapsed();

--- a/lnxcli/rustfmt.toml
+++ b/lnxcli/rustfmt.toml
@@ -1,0 +1,6 @@
+unstable_features = true
+combine_control_expr = false
+imports_layout = "HorizontalVertical"
+match_block_trailing_comma = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/lnxcli/src/main.rs
+++ b/lnxcli/src/main.rs
@@ -1,11 +1,10 @@
 #[macro_use]
 extern crate log;
 
-use structopt::StructOpt;
 use std::net::SocketAddr;
 
 use benchmark::{self, BenchMode, BenchTarget};
-
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "lnxcli", about = "A utility cli for benchmarking and testing")]
@@ -145,7 +144,7 @@ fn main() -> anyhow::Result<()> {
 
             info!("starting demo app");
             demo::run(ctx)
-        }
+        },
     }?;
 
     info!("commands complete!");

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+unstable_features = true
+combine_control_expr = false
+imports_layout = "HorizontalVertical"
+match_block_trailing_comma = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,17 +1,15 @@
 use anyhow::{Error, Result};
-
 use axum::http::header;
-
+use hashbrown::HashMap;
 use headers::HeaderMapExt;
 use hyper::http::{HeaderValue, Request, Response, StatusCode};
-use tower_http::auth::AuthorizeRequest;
-
-use hashbrown::HashMap;
 use parking_lot::Mutex;
-use rand::{distributions::Alphanumeric, Rng};
+use rand::distributions::Alphanumeric;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use sqlx::{Connection, Row, SqliteConnection};
 use tokio::fs;
+use tower_http::auth::AuthorizeRequest;
 
 /// A set of flags determining permissions.
 pub struct AuthFlags;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,27 +8,22 @@ use std::fs::File;
 use std::io::BufReader;
 use std::sync::Arc;
 
-use tokio::net::TcpListener;
-
-use tokio_rustls::rustls::internal::pemfile::{certs, pkcs8_private_keys};
-use tokio_rustls::rustls::{NoClientAuth, ServerConfig};
-use tokio_rustls::TlsAcceptor;
-
+use anyhow::{Error, Result};
 use axum::handler::{delete, get, post, Handler};
 use axum::http::header;
 use axum::Router;
-
+use fern::colors::{Color, ColoredLevelConfig};
+use hyper::http::HeaderValue;
+use hyper::server::conn::Http;
+use log::LevelFilter;
+use structopt::StructOpt;
+use tokio::net::TcpListener;
+use tokio_rustls::rustls::internal::pemfile::{certs, pkcs8_private_keys};
+use tokio_rustls::rustls::{NoClientAuth, ServerConfig};
+use tokio_rustls::TlsAcceptor;
 use tower::ServiceBuilder;
 use tower_http::auth::RequireAuthorizationLayer;
 use tower_http::set_header::SetResponseHeaderLayer;
-
-use hyper::http::HeaderValue;
-use hyper::server::conn::Http;
-
-use anyhow::{Error, Result};
-use fern::colors::{Color, ColoredLevelConfig};
-use log::LevelFilter;
-use structopt::StructOpt;
 
 mod auth;
 mod responders;
@@ -105,7 +100,7 @@ fn main() {
         Err(e) => {
             eprintln!("error during server setup: {:?}", e);
             return;
-        }
+        },
     };
 
     let threads = settings.runtime_threads.unwrap_or_else(|| num_cpus::get());
@@ -120,7 +115,7 @@ fn main() {
         Err(e) => {
             error!("error during runtime creation: {:?}", e);
             return;
-        }
+        },
     };
 
     if let Err(e) = result {
@@ -360,7 +355,7 @@ fn check_tls_files(settings: &Settings) -> Result<Option<Arc<ServerConfig>>> {
             return Err(Error::msg(
                 "missing a required TLS field, both key and cert must be provided.",
             ))
-        }
+        },
     }
 }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -7,7 +7,7 @@ use axum::extract::rejection::{JsonRejection, PathParamsRejection, QueryRejectio
 use axum::extract::{self, Extension, Path, Query};
 use axum::http::{Response, StatusCode};
 
-use engine::structures::{FieldValue, IndexDeclaration, QueryPayload, Document};
+use engine::structures::{Document, FieldValue, IndexDeclaration, QueryPayload};
 use engine::{LeasedIndex, SearchEngine};
 
 use crate::auth::{AuthManager, Permissions};

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -7,8 +7,7 @@ use axum::extract::rejection::{JsonRejection, PathParamsRejection, QueryRejectio
 use axum::extract::{self, Extension, Path, Query};
 use axum::http::{Response, StatusCode};
 
-use engine::structures::{FieldValue, IndexDeclaration, QueryPayload};
-use engine::tantivy::schema::NamedFieldDocument;
+use engine::structures::{FieldValue, IndexDeclaration, QueryPayload, Document};
 use engine::{LeasedIndex, SearchEngine};
 
 use crate::auth::{AuthManager, Permissions};
@@ -228,10 +227,10 @@ pub struct PendingQueries {
 #[serde(untagged)]
 pub enum DocumentOptions {
     /// A singular document payload.
-    Single(NamedFieldDocument),
+    Single(Document),
 
     /// An array of documents acting as a bulk insertion.
-    Many(Vec<NamedFieldDocument>),
+    Many(Vec<Document>),
 }
 
 /// Adds one or more documents to the given index.

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -318,7 +318,7 @@ pub async fn delete_documents(
         );
     }
 
-    json_response(StatusCode::OK, &())
+    json_response(StatusCode::OK, "deleted any document matching term")
 }
 
 /// Deletes all documents.

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,14 +1,13 @@
-use hashbrown::HashMap;
-use serde::Deserialize;
 use std::sync::Arc;
 
 use axum::body::{box_body, Body, BoxBody};
 use axum::extract::rejection::{JsonRejection, PathParamsRejection, QueryRejection};
 use axum::extract::{self, Extension, Path, Query};
 use axum::http::{Response, StatusCode};
-
 use engine::structures::{Document, FieldValue, IndexDeclaration, QueryPayload};
 use engine::{LeasedIndex, SearchEngine};
+use hashbrown::HashMap;
+use serde::Deserialize;
 
 use crate::auth::{AuthManager, Permissions};
 use crate::responders::json_response;
@@ -26,7 +25,7 @@ macro_rules! get_index_or_reject {
                     StatusCode::BAD_REQUEST,
                     &format!("no index exists with name '{}", $name),
                 );
-            }
+            },
             Some(index) => index,
         }
     }};
@@ -71,21 +70,21 @@ macro_rules! check_path {
                     StatusCode::BAD_REQUEST,
                     &format!("invalid path parameter {}", e),
                 );
-            }
+            },
             Err(PathParamsRejection::MissingRouteParams(e)) => {
                 warn!("rejecting request due to {:?}", e);
                 return json_response(
                     StatusCode::BAD_REQUEST,
                     &format!("missing required route parameters: {}", e),
                 );
-            }
+            },
             Err(e) => {
                 warn!("rejecting request due to {:?}", e);
                 return json_response(
                     StatusCode::BAD_REQUEST,
                     &format!("error with path handling: {}", e),
                 );
-            }
+            },
         }
     }};
 }
@@ -104,14 +103,14 @@ macro_rules! check_query {
                     StatusCode::BAD_REQUEST,
                     &format!("failed to deserialize query string: {}", e),
                 );
-            }
+            },
             Err(e) => {
                 warn!("rejecting request due to {:?}", e);
                 return json_response(
                     StatusCode::BAD_REQUEST,
                     &format!("error with query string handling: {}", e),
                 );
-            }
+            },
         }
     }};
 }
@@ -130,25 +129,25 @@ macro_rules! check_json {
                     StatusCode::BAD_REQUEST,
                     "request missing application/json content type",
                 );
-            }
+            },
             Err(JsonRejection::InvalidJsonBody(e)) => {
                 warn!("rejecting request due to invalid body: {:?}", e);
                 return json_response(
                     StatusCode::BAD_REQUEST,
                     &format!("invalid JSON body: {}", e),
                 );
-            }
+            },
             Err(JsonRejection::BodyAlreadyExtracted(_)) => {
                 warn!("rejecting request due to duplicate body extracting");
                 return json_response(StatusCode::BAD_REQUEST, "body already extracted");
-            }
+            },
             Err(e) => {
                 warn!("rejecting request due to unknown error: {:?}", e);
                 return json_response(
                     StatusCode::BAD_REQUEST,
                     &format!("error with json payload: {}", e),
                 );
-            }
+            },
         }
     }};
 }
@@ -262,7 +261,7 @@ pub async fn add_document(
                     }
                 });
             }
-        }
+        },
         DocumentOptions::Many(docs) => {
             debug!("adding multiple document to index: {}", index_name.as_str());
             if wait {
@@ -274,7 +273,7 @@ pub async fn add_document(
                     }
                 });
             }
-        }
+        },
     }
 
     json_response(

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -4,7 +4,7 @@ use axum::body::{box_body, Body, BoxBody};
 use axum::extract::rejection::{JsonRejection, PathParamsRejection, QueryRejection};
 use axum::extract::{self, Extension, Path, Query};
 use axum::http::{Response, StatusCode};
-use engine::structures::{Document, FieldValue, IndexDeclaration, QueryPayload};
+use engine::structures::{Document, IndexDeclaration, QueryPayload, DocumentValue};
 use engine::{LeasedIndex, SearchEngine};
 use hashbrown::HashMap;
 use serde::Deserialize;
@@ -302,7 +302,7 @@ pub async fn get_document(
 /// Deletes any documents matching the set of given terms.
 pub async fn delete_documents(
     index_name: Result<Path<String>, PathParamsRejection>,
-    terms: Result<extract::Json<HashMap<String, FieldValue>>, JsonRejection>,
+    terms: Result<extract::Json<HashMap<String, DocumentValue>>, JsonRejection>,
     Extension(engine): Extension<SharedEngine>,
 ) -> Response<Body> {
     let index_name = check_path!(index_name);


### PR DESCRIPTION
This fixes #16 along with:
- Writer panics when adding a document that should be a date / fast field.
- Date fields being un-addable due to unsupported deserialization.

This also adds:
- lax semantics, e.g. you can have a date field and add a document directly as either a u64 timestamp or via an rfc3339 formatted string.