### PR TITLE
feat-31 add support for multi-field term handling.

### DIFF
--- a/search-engine/search-index/src/query.rs
+++ b/search-engine/search-index/src/query.rs
@@ -17,14 +17,7 @@ use tantivy::query::{
     QueryParser,
     TermQuery,
 };
-use tantivy::schema::{
-    Facet,
-    FacetParseError,
-    Field,
-    FieldType,
-    IndexRecordOption,
-    Schema,
-};
+use tantivy::schema::{Facet, FacetParseError, Field, FieldType, IndexRecordOption, Schema, FieldEntry};
 use tantivy::tokenizer::{LowerCaser, SimpleTokenizer, TextAnalyzer};
 use tantivy::{DateTime, Index, Score, Term};
 
@@ -89,13 +82,20 @@ pub enum QueryKind {
     MoreLikeThis,
 
     /// Get results matching the given term for the given field.
-    Term(String),
+    Term(FieldSelector),
 }
 
 impl Default for QueryKind {
     fn default() -> Self {
         Self::Fuzzy
     }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum FieldSelector {
+    Single(String),
+    Multi(Vec<String>)
 }
 
 /// Defines whether a term in a query must be present,
@@ -296,7 +296,7 @@ impl QueryBuilder {
             QueryKind::Fuzzy => self.make_fuzzy_query(qry.value),
             QueryKind::Normal => self.make_normal_query(qry.value),
             QueryKind::MoreLikeThis => self.make_more_like_this_query(qry.value).await,
-            QueryKind::Term(field) => self.make_term_query(qry.value, &field),
+            QueryKind::Term(field) => self.make_term_query(qry.value, field),
         }
     }
 
@@ -443,8 +443,39 @@ impl QueryBuilder {
     fn make_term_query(
         &self,
         value: DocumentValue,
-        field: &str,
+        field: FieldSelector,
     ) -> Result<Box<dyn Query>> {
+        use tantivy::query::Occur;
+
+        let fields = {
+            match field {
+                FieldSelector::Single(field) => {
+                    vec![self.get_searchable_field(&field)?]
+                },
+                FieldSelector::Multi(fields) => {
+                    let mut search_fields = Vec::with_capacity(fields.len());
+                    for field in fields {
+                        search_fields.push(self.get_searchable_field(&field)?);
+                    }
+
+                    search_fields
+                }
+            }
+        };
+
+        let mut queries: Vec<(Occur, Box<dyn Query>)> = Vec::with_capacity(fields.len());
+        for field in fields {
+            let entry = self.schema.get_field_entry(field);
+            let term = convert_to_term(value.clone(), field, entry)?;
+
+            let query = TermQuery::new(term, IndexRecordOption::Basic);
+            queries.push((Occur::Must, Box::new(query)));
+        }
+
+        Ok(Box::new(BooleanQuery::new(queries)))
+    }
+
+    fn get_searchable_field(&self, field: &str) -> Result<Field> {
         let field = self.schema.get_field(field).ok_or_else(|| {
             Error::msg(format!("no field exists with name: {:?}", field))
         })?;
@@ -456,35 +487,7 @@ impl QueryBuilder {
             ));
         }
 
-        let term = match entry.field_type() {
-            FieldType::U64(_) => Term::from_field_u64(field, value.try_into()?),
-            FieldType::I64(_) => Term::from_field_i64(field, value.try_into()?),
-            FieldType::F64(_) => Term::from_field_f64(field, value.try_into()?),
-            FieldType::Str(_) => {
-                let value: String = value.try_into()?;
-                Term::from_field_text(field, &value)
-            },
-            FieldType::HierarchicalFacet(_) => {
-                let facet: String = value.try_into()?;
-
-                let facet = Facet::from_text(&facet).map_err(|e| {
-                    let e = match e {
-                        FacetParseError::FacetParseError(e) => e,
-                    };
-                    Error::msg(e)
-                })?;
-
-                Term::from_facet(field, &facet)
-            },
-            FieldType::Date(_) => {
-                let dt: DateTime = value.try_into()?;
-                Term::from_field_date(field, &dt)
-            },
-            _ => return Err(Error::msg("the given field is a unsupported type")),
-        };
-
-        let query = TermQuery::new(term, IndexRecordOption::Basic);
-        Ok(Box::new(query))
+        Ok(field)
     }
 }
 
@@ -507,4 +510,35 @@ fn get_parser(ctx: &QueryContext, index: &Index) -> QueryParser {
     }
 
     parser
+}
+
+fn convert_to_term(value: DocumentValue, field: Field, entry: &FieldEntry) -> Result<Term> {
+    let term = match entry.field_type() {
+        FieldType::U64(_) => Term::from_field_u64(field, value.try_into()?),
+        FieldType::I64(_) => Term::from_field_i64(field, value.try_into()?),
+        FieldType::F64(_) => Term::from_field_f64(field, value.try_into()?),
+        FieldType::Str(_) => {
+            let value: String = value.try_into()?;
+            Term::from_field_text(field, &value)
+        },
+        FieldType::HierarchicalFacet(_) => {
+            let facet: String = value.try_into()?;
+
+            let facet = Facet::from_text(&facet).map_err(|e| {
+                let e = match e {
+                    FacetParseError::FacetParseError(e) => e,
+                };
+                Error::msg(e)
+            })?;
+
+            Term::from_facet(field, &facet)
+        },
+        FieldType::Date(_) => {
+            let dt: DateTime = value.try_into()?;
+            Term::from_field_date(field, &dt)
+        },
+        _ => return Err(Error::msg("the given field is a unsupported type")),
+    };
+
+    Ok(term)
 }


### PR DESCRIPTION
This closes #31 implementing support for multi-field term queries, this cuts out the need to have a lot of duplicate query data just for searching in multiple fields.

changes are:

```json
{
  "kind": {
    "term": ["title", "description"],
  }
}
```

is not supported