### PR TITLE
38 - Add sensible writer defaults.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,5 @@
-/lnxcli
-/benchmark/datasets
+/search-engine/search-index/_dist
 /assets
-/tests
 /benchmarks
-/demo
-**/target
+/target
+/index

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN cargo build --release --target x86_64-unknown-linux-musl
 
 # Size optimization
-# RUN strip target/x86_64-unknown-linux-musl/release/lnx
+RUN strip target/x86_64-unknown-linux-musl/release/lnx
 
 # Start building the final image
 FROM scratch

--- a/search-engine/search-index/Cargo.toml
+++ b/search-engine/search-index/Cargo.toml
@@ -24,6 +24,8 @@ tantivy = "0.16"
 flate2 = "1.0.20"
 log = "0.4"
 arc-swap = "1.4.0"
+num_cpus = "1"
+sysinfo = "0.20.5"
 
 aexecutor = { path = "../aexecutor" }
 

--- a/search-engine/search-index/src/index.rs
+++ b/search-engine/search-index/src/index.rs
@@ -663,7 +663,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zero_buffer_expect_err() -> Result<()> {
+    async fn zero_buffer_expect_defaulting() -> Result<()> {
         init_state();
 
         let res = get_index_with(serde_json::json!({
@@ -704,6 +704,48 @@ mod tests {
         .await;
 
         assert!(res.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn default_writer_settings_expect_ok() -> Result<()> {
+        init_state();
+
+        let res = get_index_with(serde_json::json!({
+            "name": "test_index_0_buffer_expect_err",
+
+            // Reader context
+            "reader_threads": 1,
+            "max_concurrency": 1,
+
+            "storage_type": "memory",
+            "fields": {
+                "title": {
+                    "type": "text",
+                    "stored": true
+                },
+                "description": {
+                    "type": "string",
+                    "stored": false
+                },
+                "count": {
+                   "type": "u64",
+                   "stored": true,
+                   "indexed": true,
+                   "fast": "single"
+                },
+            },
+
+            // The query context
+            "search_fields": [
+                "title",
+                "description",
+            ],
+        }))
+        .await;
+
+        assert!(res.is_ok());
 
         Ok(())
     }

--- a/search-engine/search-index/src/index.rs
+++ b/search-engine/search-index/src/index.rs
@@ -703,7 +703,7 @@ mod tests {
         }))
         .await;
 
-        assert!(res.is_err());
+        assert!(res.is_ok());
 
         Ok(())
     }

--- a/search-engine/search-index/src/query.rs
+++ b/search-engine/search-index/src/query.rs
@@ -17,7 +17,15 @@ use tantivy::query::{
     QueryParser,
     TermQuery,
 };
-use tantivy::schema::{Facet, FacetParseError, Field, FieldType, IndexRecordOption, Schema, FieldEntry};
+use tantivy::schema::{
+    Facet,
+    FacetParseError,
+    Field,
+    FieldEntry,
+    FieldType,
+    IndexRecordOption,
+    Schema,
+};
 use tantivy::tokenizer::{LowerCaser, SimpleTokenizer, TextAnalyzer};
 use tantivy::{DateTime, Index, Score, Term};
 
@@ -95,7 +103,7 @@ impl Default for QueryKind {
 #[serde(untagged)]
 pub enum FieldSelector {
     Single(String),
-    Multi(Vec<String>)
+    Multi(Vec<String>),
 }
 
 /// Defines whether a term in a query must be present,
@@ -464,7 +472,7 @@ impl QueryBuilder {
                     }
 
                     search_fields
-                }
+                },
             }
         };
 
@@ -517,7 +525,11 @@ fn get_parser(ctx: &QueryContext, index: &Index) -> QueryParser {
     parser
 }
 
-fn convert_to_term(value: DocumentValue, field: Field, entry: &FieldEntry) -> Result<Term> {
+fn convert_to_term(
+    value: DocumentValue,
+    field: Field,
+    entry: &FieldEntry,
+) -> Result<Term> {
     let term = match entry.field_type() {
         FieldType::U64(_) => Term::from_field_u64(field, value.try_into()?),
         FieldType::I64(_) => Term::from_field_i64(field, value.try_into()?),

--- a/search-engine/search-index/src/writer.rs
+++ b/search-engine/search-index/src/writer.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use sysinfo::SystemExt;
 use anyhow::{Error, Result};
 use crossbeam::channel;
 use crossbeam::queue::SegQueue;
 use serde::{Deserialize, Serialize};
+use sysinfo::SystemExt;
 use tantivy::schema::{Field, Schema};
 use tantivy::{IndexWriter, Opstamp, Term};
 use tokio::sync::oneshot;
@@ -16,14 +16,12 @@ use crate::stop_words::{PersistentStopWordManager, StopWordManager};
 use crate::storage::StorageBackend;
 use crate::structures::{DocumentPayload, IndexContext, INDEX_STORAGE_PATH};
 
-
 type OpPayload = (WriterOp, Option<oneshot::Sender<Result<()>>>);
 type OpReceiver = channel::Receiver<OpPayload>;
 type OpSender = channel::Sender<OpPayload>;
 type WaitersQueue = Arc<SegQueue<oneshot::Sender<()>>>;
 type ShutdownWaker = async_channel::Sender<()>;
 type ShutdownReceiver = async_channel::Receiver<()>;
-
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub(crate) struct WriterContext {
@@ -392,7 +390,7 @@ impl Writer {
 
             debug!(
                 "[ WRITER @ {} ] index writer setup threads={}, heap={}B ",
-                &ctx.name,  writer_ctx.writer_threads, writer_ctx.writer_buffer,
+                &ctx.name, writer_ctx.writer_threads, writer_ctx.writer_buffer,
             );
 
             ctx.index.writer_with_num_threads(

--- a/search-engine/search-index/src/writer.rs
+++ b/search-engine/search-index/src/writer.rs
@@ -108,8 +108,9 @@ impl WriterContext {
         let free_mem = sys.free_memory();
         if buffer < (free_mem * 1000) as usize {
             return Err(Error::msg(format!(
-                "cannot allocate {}KB due to system not having enough free memory.",
-                buffer,
+                "cannot allocate {}KB due to system not having enough free memory. (Free: {}KB)",
+                buffer / 1_000,
+                free_mem
             )));
         }
 

--- a/search-engine/search-index/src/writer.rs
+++ b/search-engine/search-index/src/writer.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use sysinfo::SystemExt;
 use anyhow::{Error, Result};
 use crossbeam::channel;
 use crossbeam::queue::SegQueue;
@@ -14,8 +15,7 @@ use crate::helpers::{FrequencyCounter, PersistentFrequencySet, Validate};
 use crate::stop_words::{PersistentStopWordManager, StopWordManager};
 use crate::storage::StorageBackend;
 use crate::structures::{DocumentPayload, IndexContext, INDEX_STORAGE_PATH};
-use sysinfo::SystemExt;
-use crate::writer::defaults::HEAP_SIZE_MAX;
+
 
 type OpPayload = (WriterOp, Option<oneshot::Sender<Result<()>>>);
 type OpReceiver = channel::Receiver<OpPayload>;
@@ -49,7 +49,7 @@ mod defaults {
 
     /// We impose the memory per thread to be at least 3 MB.
     pub const HEAP_SIZE_MIN: usize = ((MARGIN_IN_BYTES as u32) * 3u32) as usize;
-    pub const HEAP_SIZE_MAX: usize = u32::MAX() as usize - MARGIN_IN_BYTES;
+    pub const HEAP_SIZE_MAX: usize = u32::MAX as usize - MARGIN_IN_BYTES;
 
     /// The default amount of writer threads to use if left out of
     /// the index creation payload.

--- a/search-engine/search-index/src/writer.rs
+++ b/search-engine/search-index/src/writer.rs
@@ -106,7 +106,7 @@ impl WriterContext {
         }
 
         let free_mem = sys.free_memory();
-        if buffer < (free_mem * 1000) as usize {
+        if buffer > (free_mem * 1000) as usize {
             return Err(Error::msg(format!(
                 "cannot allocate {}KB due to system not having enough free memory. (Free: {}KB)",
                 buffer / 1_000,

--- a/search-engine/search-index/src/writer.rs
+++ b/search-engine/search-index/src/writer.rs
@@ -220,7 +220,7 @@ impl IndexWriterWorker {
             WriterOp::DeleteTerm(term) => (self.writer.delete_term(term), "DELETE-TERM"),
             WriterOp::DeleteAll => {
                 self.frequencies.clear_frequencies();
-                self.stop_words.commit()?;
+                self.frequencies.commit()?;
                 (self.writer.delete_all_documents()?, "DELETE-ALL")
             },
             WriterOp::AddStopWords(words) => {
@@ -264,6 +264,8 @@ fn start_writer(
 ) -> Result<()> {
     let stop_words = PersistentStopWordManager::new(conn.clone(), stop_word_manager)?;
     let frequency_set = PersistentFrequencySet::new(conn)?;
+    corrections.adjust_index_frequencies(&frequency_set);
+
     let worker = IndexWriterWorker {
         frequencies: frequency_set,
         index_name: name.clone(),


### PR DESCRIPTION
This adds a set of sensible defaults in case the fields are left out.

Closes #38 
## Thread defaults
The logical CPU count is used if its count is less than `8`.  8 threads are the max default limit. 
*NOTE: You can still manually set a higher number of threads.*

## Buffer sizes
This defaults to 10% of the total memory of the server, if this is less than the minimum heap size (`3MB * num_threads`) the minimum is used, if this is larger than the max size it's capped to the max.