### PR TITLE
42 - Add MiMalloc allocator

### DIFF
--- a/lnx-server/Cargo.toml
+++ b/lnx-server/Cargo.toml
@@ -28,4 +28,7 @@ headers = "0.3.4"
 parking_lot = "0.11"
 rand = "0.8.4"
 
+# allocator
+mimalloc = { version = "*", default-features = false }
+
 engine = { path = "../search-engine/engine" }

--- a/lnx-server/src/main.rs
+++ b/lnx-server/src/main.rs
@@ -18,6 +18,11 @@ use hyper::Server;
 use log::LevelFilter;
 use routerify::RouterService;
 use structopt::StructOpt;
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 
 use crate::auth::AuthManager;
 use crate::state::State;


### PR DESCRIPTION
Closes #42 

This adds MiMalloc as the global allocator for lnx, this should allow for more consistent performance across operating systems and containers as Musl's allocator has a history of bad performance.

For those wondering why JeMalloc was not used, there is an interesting compile-time error when linking with it, it also doesn't support windows which I feel like the consistency is an important factor.