### PR TITLE
[ Performance ] update symspell to use custom fork 

### DIFF
--- a/lnx-server/src/main.rs
+++ b/lnx-server/src/main.rs
@@ -189,7 +189,7 @@ async fn create_state(settings: &Settings) -> Result<State> {
     let storage = StorageBackend::connect(Some(STORAGE_PATH.to_string()))?;
     let engine = {
         info!("loading existing indexes...");
-        let raw_structure= storage.load_structure(INDEX_KEYSPACE)?;
+        let raw_structure = storage.load_structure(INDEX_KEYSPACE)?;
         let existing_indexes: Vec<IndexDeclaration> = if let Some(buff) = raw_structure {
             let buffer: Vec<u8> = bincode::deserialize(&buff)?;
             serde_json::from_slice(&buffer)?

--- a/lnx-server/src/main.rs
+++ b/lnx-server/src/main.rs
@@ -189,13 +189,13 @@ async fn create_state(settings: &Settings) -> Result<State> {
     let storage = StorageBackend::connect(Some(STORAGE_PATH.to_string()))?;
     let engine = {
         info!("loading existing indexes...");
-        let existing_indexes: Vec<IndexDeclaration>;
-        if let Some(buff) = storage.load_structure(INDEX_KEYSPACE)? {
+        let raw_structure= storage.load_structure(INDEX_KEYSPACE)?;
+        let existing_indexes: Vec<IndexDeclaration> = if let Some(buff) = raw_structure {
             let buffer: Vec<u8> = bincode::deserialize(&buff)?;
-            existing_indexes = serde_json::from_slice(&buffer)?;
+            serde_json::from_slice(&buffer)?
         } else {
-            existing_indexes = vec![];
-        }
+            vec![]
+        };
 
         info!(
             " {} existing indexes discovered, recreating state...",

--- a/search-engine/search-index/Cargo.toml
+++ b/search-engine/search-index/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 hashbrown = { version = "0.11", features = ["serde"] }
-symspell = { git = "https://github.com/ChillFish8/symspell", branch = "0.6.0" }
+symspell = { git = "https://github.com/lnx-search/symspell", branch = "master" }
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.12", features = ["sync", "fs", "rt"] }
 compress = { version = "0.2.1", default-features=false, features = ["lz4"] }

--- a/search-engine/search-index/src/corrections.rs
+++ b/search-engine/search-index/src/corrections.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use symspell::{SymSpell, UnicodeiStringStrategy};
+use symspell::{SymSpell, AsciiStringStrategy};
 
 use crate::helpers::FrequencyCounter;
 
@@ -10,7 +10,7 @@ pub(crate) type SymSpellCorrectionManager = Arc<SymSpellManager>;
 
 /// The manager around the sym spell fuzzy searching system.
 pub(crate) struct SymSpellManager {
-    sym: Arc<ArcSwap<SymSpell<UnicodeiStringStrategy>>>,
+    sym: Arc<ArcSwap<SymSpell<AsciiStringStrategy>>>,
 }
 
 impl SymSpellManager {
@@ -24,25 +24,7 @@ impl SymSpellManager {
     ///
     /// If the index does not have a set of frequencies this returns the original string.
     pub(crate) fn correct(&self, sentence: &str) -> String {
-        let mut results = { self.sym.load().lookup_compound(sentence, 1) };
-
-        if results.is_empty() {
-            sentence.to_string()
-        } else {
-            let v = results.remove(0);
-            v.term
-        }
-    }
-
-    /// Gets all predicted corrections for a given sentence.
-    pub(crate) fn get_corrections(&self, sentence: &str) -> Vec<String> {
-        let mut results = { self.sym.load().lookup_compound(sentence, 1) };
-
-        if results.is_empty() {
-            vec![sentence.to_string()]
-        } else {
-            results.drain(..).map(|s| s.term).collect()
-        }
+        return self.sym.load().lookup_compound(sentence, 2);
     }
 
     /// Sets a custom symspell handler for the given index.
@@ -50,8 +32,13 @@ impl SymSpellManager {
     /// This means when something is next set to be corrected for the index, the
     /// custom frequencies will be used instead of the default.
     pub(crate) fn adjust_index_frequencies(&self, frequencies: &impl FrequencyCounter) {
-        let mut symspell: SymSpell<UnicodeiStringStrategy> = SymSpell::default();
-        symspell.load_dictionary_from_map(frequencies.counts().clone());
+        let mut symspell: SymSpell<AsciiStringStrategy> = SymSpell::default();
+        symspell.using_dictionary_frequencies(
+            frequencies.counts()
+                .into_iter()
+                .map(|(k, v)| (k.clone(), *v as i64))
+                .collect()
+        );
 
         self.sym.store(Arc::from(symspell))
     }

--- a/search-engine/search-index/src/corrections.rs
+++ b/search-engine/search-index/src/corrections.rs
@@ -24,7 +24,7 @@ impl SymSpellManager {
     ///
     /// If the index does not have a set of frequencies this returns the original string.
     pub(crate) fn correct(&self, sentence: &str) -> String {
-        return self.sym.load().lookup_compound(sentence, 2);
+        self.sym.load().lookup_compound(sentence, 2)
     }
 
     /// Sets a custom symspell handler for the given index.

--- a/search-engine/search-index/src/corrections.rs
+++ b/search-engine/search-index/src/corrections.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use symspell::{SymSpell, AsciiStringStrategy};
+use symspell::{AsciiStringStrategy, SymSpell};
 
 use crate::helpers::FrequencyCounter;
 
@@ -34,10 +34,11 @@ impl SymSpellManager {
     pub(crate) fn adjust_index_frequencies(&self, frequencies: &impl FrequencyCounter) {
         let mut symspell: SymSpell<AsciiStringStrategy> = SymSpell::default();
         symspell.using_dictionary_frequencies(
-            frequencies.counts()
+            frequencies
+                .counts()
                 .into_iter()
                 .map(|(k, v)| (k.clone(), *v as i64))
-                .collect()
+                .collect(),
         );
 
         self.sym.store(Arc::from(symspell))

--- a/search-engine/search-index/src/helpers.rs
+++ b/search-engine/search-index/src/helpers.rs
@@ -136,11 +136,11 @@ impl PersistentFrequencySet {
     fn load_frequencies_from_store(&mut self) -> Result<()> {
         info!("[ FREQUENCY-COUNTER ] loading frequencies from persistent backend.");
 
-        let frequencies: HashMap<String, u32>;
-        if let Some(buff) = self.conn.load_structure(Self::KEYSPACE)? {
-            frequencies = deserialize(&buff)?;
+        let raw_structure = self.conn.load_structure(Self::KEYSPACE)?;
+        let frequencies: HashMap<String, u32> = if let Some(buff) = raw_structure {
+            deserialize(&buff)?
         } else {
-            frequencies = HashMap::new();
+            HashMap::new()
         };
 
         for (word, count) in frequencies {

--- a/search-engine/search-index/src/query.rs
+++ b/search-engine/search-index/src/query.rs
@@ -296,7 +296,8 @@ impl QueryBuilder {
 
     /// Gets a list of suggested corrections based off of the index corpus.
     pub(crate) fn get_corrections(&self, query: &str) -> Vec<String> {
-        self.corrections.get_corrections(query)
+        // TODO: reflect single output changes
+        vec![self.corrections.correct(query)]
     }
 
     /// Gets the unique document id field.

--- a/search-engine/search-index/src/storage.rs
+++ b/search-engine/search-index/src/storage.rs
@@ -19,13 +19,12 @@ pub struct StorageBackend {
 impl StorageBackend {
     /// Connects to the sqlite DB.
     pub fn connect(fp: Option<String>) -> Result<Self> {
-        let conn: Arc<dyn Directory>;
-        if let Some(ref fp) = fp {
+        let conn: Arc<dyn Directory> = if let Some(ref fp) = fp {
             std::fs::create_dir_all(fp)?;
-            conn = Arc::new(MmapDirectory::open(fp)?)
+            Arc::new(MmapDirectory::open(fp)?)
         } else {
-            conn = Arc::new(RamDirectory::create());
-        }
+            Arc::new(RamDirectory::create())
+        };
 
         Ok(Self { fp, conn })
     }

--- a/search-engine/search-index/src/structures.rs
+++ b/search-engine/search-index/src/structures.rs
@@ -254,12 +254,12 @@ impl IndexDeclaration {
 
         let corrections = Arc::new(SymSpellManager::new());
 
-        let fp;
-        if let StorageType::FileSystem = self.storage_type {
-            fp = Some(format!("{}/{}", INDEX_METADATA_PATH, &self.name))
+        let fp = if let StorageType::FileSystem = self.storage_type {
+            Some(format!("{}/{}", INDEX_METADATA_PATH, &self.name))
         } else {
-            fp = None;
-        }
+            None
+        };
+
         let storage = StorageBackend::connect(fp)?;
 
         Ok(IndexContext {


### PR DESCRIPTION
This adds/swaps our usage of the symspell crate on my original fork to the org's fork.

This brings with it significant memory saving optimisations most notably due to de-duplication and around a ~1.5-2x performance boost.