### PR TITLE
Reserve query design and change Term Query.

### DIFF
--- a/lnx-engine/search-index/Cargo.toml
+++ b/lnx-engine/search-index/Cargo.toml
@@ -15,6 +15,7 @@ symspell = { git = "https://github.com/lnx-search/symspell", branch = "master" }
 hashbrown = { version = "0.11", features = ["serde"] }
 tokio = { version = "1.12", features = ["sync", "fs", "rt"] }
 
+serde_json = "1.0.74"
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 crc32fast = "1.3.0"

--- a/lnx-engine/search-index/Cargo.toml
+++ b/lnx-engine/search-index/Cargo.toml
@@ -15,7 +15,6 @@ symspell = { git = "https://github.com/lnx-search/symspell", branch = "master" }
 hashbrown = { version = "0.11", features = ["serde"] }
 tokio = { version = "1.12", features = ["sync", "fs", "rt"] }
 
-serde_json = "1.0.74"
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 crc32fast = "1.3.0"

--- a/lnx-engine/search-index/src/index.rs
+++ b/lnx-engine/search-index/src/index.rs
@@ -1531,8 +1531,7 @@ mod tests {
 
         let query: QueryPayload = serde_json::from_value(serde_json::json!({
             "query": {
-                "value": "ol man",
-                "kind": "fuzzy"
+                "fuzzy": {"ctx": "ol man"},
             },
         }))?;
 
@@ -1566,8 +1565,7 @@ mod tests {
 
         let query: QueryPayload = serde_json::from_value(serde_json::json!({
             "query": {
-                "value": "ol",
-                "kind": "fuzzy"
+                "fuzzy": {"ctx": "ol"},
             },
         }))?;
 
@@ -1590,8 +1588,7 @@ mod tests {
 
         let query: QueryPayload = serde_json::from_value(serde_json::json!({
             "query": {
-                "value": "*",
-                "kind": "normal"
+                "normal": {"ctx": "*"},
             },
         }))?;
 
@@ -1614,8 +1611,7 @@ mod tests {
 
         let query: QueryPayload = serde_json::from_value(serde_json::json!({
             "query": {
-                "value": "man",
-                "kind": "normal"
+                "normal": {"ctx": "man"},
             },
         }))?;
 
@@ -1631,8 +1627,7 @@ mod tests {
 
         let query: QueryPayload = serde_json::from_value(serde_json::json!({
             "query": {
-                "value": doc_id,
-                "kind": "more-like-this"
+                "more-like-this": {"ctx": doc_id},
             },
         }))?;
         let results = index.search(query).await.map_err(|e| {
@@ -1654,10 +1649,7 @@ mod tests {
 
         let query: QueryPayload = serde_json::from_value(serde_json::json!({
             "query": {
-                "value": "man",
-                "kind": {
-                    "term": "title"
-                }
+                "term": {"ctx": "man", "fields": "title"},
             },
         }))?;
 
@@ -1680,10 +1672,7 @@ mod tests {
 
         let query: QueryPayload = serde_json::from_value(serde_json::json!({
             "query": {
-                "value": "/tools",
-                "kind": {
-                    "term": "category"
-                }
+                "term": {"ctx": "/tools", "fields": "category"},
             },
         }))?;
 
@@ -1696,10 +1685,7 @@ mod tests {
 
         let query: QueryPayload = serde_json::from_value(serde_json::json!({
             "query": {
-                "value": "/tools/hammers",
-                "kind": {
-                    "term": "category"
-                }
+                "term": {"ctx": "/tools/hammers", "fields": "category"},
             },
         }))?;
 
@@ -1723,15 +1709,11 @@ mod tests {
         let query: QueryPayload = serde_json::from_value(serde_json::json!({
             "query": [
                 {
-                     "value": "extra",
-                     "kind": "normal",
+                    "normal": {"ctx": "extra"},
                     "occur": "must",
                 },
                 {
-                    "value": "3",
-                    "kind": {
-                        "term": "count"
-                    },
+                    "term": {"ctx": "3", "fields": "count"},
                     "occur": "must",
                 },
             ],

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -86,9 +86,11 @@ pub enum QueryKind {
     MoreLikeThis { ctx: DocumentValue },
 
     /// Get results matching the given term for the given field.
-    Term { ctx: DocumentValue, fields: FieldSelector },
+    Term {
+        ctx: DocumentValue,
+        fields: FieldSelector,
+    },
 }
-
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
@@ -183,14 +185,18 @@ impl<'de> Deserialize<'de> for QuerySelector {
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> {
                 Ok(QuerySelector::Single(QueryData {
-                    kind: QueryKind::Fuzzy { ctx: DocumentValue::Text(v.to_string()) },
+                    kind: QueryKind::Fuzzy {
+                        ctx: DocumentValue::Text(v.to_string()),
+                    },
                     occur: Occur::default(),
                 }))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> {
                 Ok(QuerySelector::Single(QueryData {
-                    kind: QueryKind::Fuzzy { ctx: DocumentValue::Text(v.to_string()) },
+                    kind: QueryKind::Fuzzy {
+                        ctx: DocumentValue::Text(v),
+                    },
                     occur: Occur::default(),
                 }))
             }
@@ -301,8 +307,12 @@ impl QueryBuilder {
         match qry.kind {
             QueryKind::Fuzzy { ctx: query } => self.make_fuzzy_query(query),
             QueryKind::Normal { ctx: query } => self.make_normal_query(query),
-            QueryKind::MoreLikeThis { ctx: query } => self.make_more_like_this_query(query).await,
-            QueryKind::Term { ctx: query, fields }  => self.make_term_query(query, fields),
+            QueryKind::MoreLikeThis { ctx: query } => {
+                self.make_more_like_this_query(query).await
+            },
+            QueryKind::Term { ctx: query, fields } => {
+                self.make_term_query(query, fields)
+            },
         }
     }
 

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -72,21 +72,21 @@ pub enum QueryKind {
     /// within reason will be corrected and not invalidate all the results.
     ///
     /// Things like `trueman show` will match `the truman show`.
-    Fuzzy { query: DocumentValue },
+    Fuzzy { ctx: DocumentValue },
 
     /// The normal query search using the tantivy query parser.
     ///
     /// This will expect the given value to follow the query specification
     /// as defined in the tantivy docs.
-    Normal { query: DocumentValue },
+    Normal { ctx: DocumentValue },
 
     /// Gets similar documents based on the reference document.
     ///
     /// This expects a document id as the value, anything else will be rejected.
-    MoreLikeThis { query: DocumentValue },
+    MoreLikeThis { ctx: DocumentValue },
 
     /// Get results matching the given term for the given field.
-    Term { query: DocumentValue, fields: FieldSelector },
+    Term { ctx: DocumentValue, fields: FieldSelector },
 }
 
 
@@ -183,14 +183,14 @@ impl<'de> Deserialize<'de> for QuerySelector {
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> {
                 Ok(QuerySelector::Single(QueryData {
-                    kind: QueryKind::Fuzzy { query: DocumentValue::Text(v.to_string()) },
+                    kind: QueryKind::Fuzzy { ctx: DocumentValue::Text(v.to_string()) },
                     occur: Occur::default(),
                 }))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> {
                 Ok(QuerySelector::Single(QueryData {
-                    kind: QueryKind::Fuzzy { query: DocumentValue::Text(v.to_string()) },
+                    kind: QueryKind::Fuzzy { ctx: DocumentValue::Text(v.to_string()) },
                     occur: Occur::default(),
                 }))
             }
@@ -299,10 +299,10 @@ impl QueryBuilder {
     /// Builds a query from the given query payload.
     async fn get_query_from_payload(&self, qry: QueryData) -> Result<Box<dyn Query>> {
         match qry.kind {
-            QueryKind::Fuzzy { query } => self.make_fuzzy_query(query),
-            QueryKind::Normal { query } => self.make_normal_query(query),
-            QueryKind::MoreLikeThis { query } => self.make_more_like_this_query(query).await,
-            QueryKind::Term { query, fields }  => self.make_term_query(query, fields),
+            QueryKind::Fuzzy { ctx: query } => self.make_fuzzy_query(query),
+            QueryKind::Normal { ctx: query } => self.make_normal_query(query),
+            QueryKind::MoreLikeThis { ctx: query } => self.make_more_like_this_query(query).await,
+            QueryKind::Term { ctx: query, fields }  => self.make_term_query(query, fields),
         }
     }
 

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -200,7 +200,7 @@ impl<'de> Deserialize<'de> for QuerySelector {
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> {
                 Ok(QuerySelector::Single(QueryData {
                     value: DocumentValue::Text(v.to_string()),
-                    context: Default::default(),
+                    context: Value::Null,
                     kind: QueryKind::default(),
                     occur: Occur::default(),
                 }))
@@ -209,7 +209,7 @@ impl<'de> Deserialize<'de> for QuerySelector {
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> {
                 Ok(QuerySelector::Single(QueryData {
                     value: DocumentValue::Text(v),
-                    context: Default::default(),
+                    context: Value::Null,
                     kind: QueryKind::default(),
                     occur: Occur::default(),
                 }))
@@ -322,7 +322,7 @@ impl QueryBuilder {
             QueryKind::Fuzzy => self.make_fuzzy_query(qry.value),
             QueryKind::Normal => self.make_normal_query(qry.value),
             QueryKind::MoreLikeThis => self.make_more_like_this_query(qry.value).await,
-            QueryKind::Term => self.make_term_query(qry.value, field),
+            QueryKind::Term => self.make_term_query(qry.value, qry.context),
         }
     }
 


### PR DESCRIPTION
This implements the small move from using enum based values in the query kind's to provide additional context, to providing all context for the query.

This is mostly down to making it easier for us to adjust the requirements of each field as and when they're required making it nicer to be displayed for documentation and feels more natural for anyone coming from ES.