### PR TITLE
Handle unix signals better preventing more issues like #64

### DIFF
--- a/lnx-engine/search-index/src/storage.rs
+++ b/lnx-engine/search-index/src/storage.rs
@@ -48,7 +48,7 @@ impl OpenType {
 ///
 /// The only difference is Tantivy's special `meta.json` and `managed.json` is
 /// ignored and kept mount to the mmap directory.
-/// This same logic is applied to watching files, only those aformentioned files
+/// This same logic is applied to watching files, only those aforementioned files
 /// are watched.
 #[derive(Clone)]
 pub struct SledBackedDirectory {

--- a/lnx-server/Cargo.toml
+++ b/lnx-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lnx"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Harrison Burt <57491488+ChillFish8@users.noreply.github.com>"]
 edition = "2018"
 description = "The adaptable deployment of the tantivy search engine. Standing on the shoulders of giants. Documentation available at https://docs.lnx.rs."

--- a/lnx-server/src/main.rs
+++ b/lnx-server/src/main.rs
@@ -307,8 +307,7 @@ async fn wait_for_signal() -> Result<()> {
 
     #[cfg(unix)]
     {
-        use tokio::signal::unix::SignalKind;
-        use tokio::signal::unix::signal;
+        use tokio::signal::unix::{signal, SignalKind};
 
         let mut stream_quit = signal(SignalKind::quit())?;
         let mut stream_interupt = signal(SignalKind::interrupt())?;
@@ -323,7 +322,6 @@ async fn wait_for_signal() -> Result<()> {
 
     Ok(())
 }
-
 
 async fn create_state(settings: &Settings) -> Result<State> {
     let db = sled::Config::new()

--- a/lnx-server/src/main.rs
+++ b/lnx-server/src/main.rs
@@ -283,7 +283,7 @@ async fn start(settings: Settings) -> Result<()> {
     );
 
     tokio::select! {
-        _r = tokio::signal::ctrl_c() => {
+        _r = wait_for_signal() => {
             info!("got shutdown signal, preparing shutdown");
         },
         r = server => {
@@ -298,6 +298,32 @@ async fn start(settings: Settings) -> Result<()> {
 
     Ok(())
 }
+
+async fn wait_for_signal() -> Result<()> {
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await?;
+    }
+
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::SignalKind;
+        use tokio::signal::unix::signal;
+
+        let mut stream_quit = signal(SignalKind::quit())?;
+        let mut stream_interupt = signal(SignalKind::interrupt())?;
+        let mut stream_term = signal(SignalKind::terminate())?;
+
+        tokio::select! {
+            _ = stream_quit.recv() => {},
+            _ = stream_interupt.recv() => {},
+            _ = stream_term.recv() => {},
+        }
+    }
+
+    Ok(())
+}
+
 
 async fn create_state(settings: &Settings) -> Result<State> {
     let db = sled::Config::new()


### PR DESCRIPTION
This PR fixes / prevent issues arising from the process not shutting down correctly due to a signal other than `SIGINT` being sent to the server in order to shut the process down.

We're essentially just adding additional listeners for `SIGINT`, `SIGTERM` and `SIGQUIT` which should cover most systems' default way of shutting processes down.

Hopefully prevents #64 