### PR TITLE
Improve schema validations and Query logic

### DIFF
--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -74,7 +74,6 @@ impl QueryData {
     }
 }
 
-
 /// A customisable set of edit distance limitations.
 ///
 /// This changes the minimum required word length for a edit distance of 1 and 2.
@@ -106,7 +105,6 @@ impl Default for FuzzyConfig {
         }
     }
 }
-
 
 #[derive(Debug, Copy, Clone, Deserialize)]
 pub struct MoreLikeThisConfig {
@@ -140,7 +138,7 @@ impl Default for MoreLikeThisConfig {
             min_word_length: Self::min_word_length(),
             max_word_length: Self::max_word_length(),
             boost_factor: Self::boost_factor(),
-            max_query_terms: None
+            max_query_terms: None,
         }
     }
 }
@@ -216,7 +214,6 @@ pub enum QueryKind {
         fields: FieldSelector,
     },
 }
-
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
@@ -433,12 +430,11 @@ impl QueryBuilder {
     /// Builds a query from the given query payload.
     async fn get_query_from_payload(&self, qry: QueryData) -> Result<Box<dyn Query>> {
         match qry.kind {
-            QueryKind::Fuzzy { ctx: query, cfg} =>
-                self.make_fuzzy_query(query, cfg),
-            QueryKind::Normal { ctx: query } =>
-                self.make_normal_query(query),
-            QueryKind::MoreLikeThis { ctx: query, cfg } =>
-                self.make_more_like_this_query(query,cfg, ).await,
+            QueryKind::Fuzzy { ctx: query, cfg } => self.make_fuzzy_query(query, cfg),
+            QueryKind::Normal { ctx: query } => self.make_normal_query(query),
+            QueryKind::MoreLikeThis { ctx: query, cfg } => {
+                self.make_more_like_this_query(query, cfg).await
+            },
             QueryKind::Term { ctx: query, fields } => {
                 self.make_term_query(query, fields)
             },
@@ -499,7 +495,8 @@ impl QueryBuilder {
                 let query: Box<dyn Query> = if self.ctx.use_fast_fuzzy {
                     Box::new(TermQuery::new(term, IndexRecordOption::WithFreqs))
                 } else {
-                    let edit_distance = if search_term.len() >= cfg.min_length_distance2 {
+                    let edit_distance = if search_term.len() >= cfg.min_length_distance2
+                    {
                         2
                     } else if search_term.len() >= cfg.min_length_distance1 {
                         1
@@ -507,7 +504,11 @@ impl QueryBuilder {
                         0
                     };
 
-                    Box::new(FuzzyTermQuery::new_prefix(term, edit_distance, !cfg.transposition_costs_two))
+                    Box::new(FuzzyTermQuery::new_prefix(
+                        term,
+                        edit_distance,
+                        !cfg.transposition_costs_two,
+                    ))
                 };
 
                 if *boost > 0.0f32 {

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -508,7 +508,8 @@ impl QueryBuilder {
                 let query: Box<dyn Query> = if self.ctx.use_fast_fuzzy {
                     Box::new(TermQuery::new(term, IndexRecordOption::WithFreqs))
                 } else {
-                    let edit_distance = if search_term.len() >= cfg.min_length_distance2 {
+                    let edit_distance = if search_term.len() >= cfg.min_length_distance2
+                    {
                         2
                     } else if search_term.len() >= cfg.min_length_distance1 {
                         1

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -90,8 +90,8 @@ impl QueryData {
 /// user.
 #[derive(Debug, Copy, Clone, Deserialize)]
 pub struct FuzzyConfig {
-    d1: usize,
-    d2: usize,
+    min_length_distance1: usize,
+    min_length_distance2: usize,
 
     #[serde(default)]
     transposition_costs_two: bool,
@@ -100,8 +100,8 @@ pub struct FuzzyConfig {
 impl Default for FuzzyConfig {
     fn default() -> Self {
         Self {
-            d1: 8,
-            d2: 5,
+            min_length_distance1: 8,
+            min_length_distance2: 5,
             transposition_costs_two: false,
         }
     }
@@ -499,9 +499,9 @@ impl QueryBuilder {
                 let query: Box<dyn Query> = if self.ctx.use_fast_fuzzy {
                     Box::new(TermQuery::new(term, IndexRecordOption::WithFreqs))
                 } else {
-                    let edit_distance = if search_term.len() >= cfg.d2 {
+                    let edit_distance = if search_term.len() >= cfg.min_length_distance2 {
                         2
-                    } else if search_term.len() >= cfg.d1 {
+                    } else if search_term.len() >= cfg.min_length_distance1 {
                         1
                     } else {
                         0

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -89,7 +89,10 @@ impl QueryData {
 /// user.
 #[derive(Debug, Copy, Clone, Deserialize)]
 pub struct FuzzyConfig {
+    #[serde(default = "FuzzyConfig::default_min_length_d1")]
     min_length_distance1: usize,
+
+    #[serde(default = "FuzzyConfig::default_min_length_d2")]
     min_length_distance2: usize,
 
     #[serde(default)]
@@ -99,10 +102,20 @@ pub struct FuzzyConfig {
 impl Default for FuzzyConfig {
     fn default() -> Self {
         Self {
-            min_length_distance1: 8,
-            min_length_distance2: 5,
+            min_length_distance1: Self::default_min_length_d1(),
+            min_length_distance2: Self::default_min_length_d2(),
             transposition_costs_two: false,
         }
+    }
+}
+
+impl FuzzyConfig {
+    pub fn default_min_length_d1() -> usize {
+        5
+    }
+
+    pub fn default_min_length_d2() -> usize {
+        8
     }
 }
 
@@ -188,7 +201,7 @@ pub enum QueryKind {
     Fuzzy {
         ctx: DocumentValue,
 
-        #[serde(flatten, default)]
+        #[serde(flatten)]
         cfg: FuzzyConfig,
     },
 
@@ -204,7 +217,7 @@ pub enum QueryKind {
     MoreLikeThis {
         ctx: DocumentValue,
 
-        #[serde(flatten, default)]
+        #[serde(flatten)]
         cfg: MoreLikeThisConfig,
     },
 

--- a/lnx-server/Cargo.toml
+++ b/lnx-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lnx"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Harrison Burt <57491488+ChillFish8@users.noreply.github.com>"]
 edition = "2018"
 description = "The adaptable deployment of the tantivy search engine. Standing on the shoulders of giants. Documentation available at https://docs.lnx.rs."


### PR DESCRIPTION
This improves some of the schema validations so that you get an error when submitting a index payload if search fields don't exist or boost fields don't exist.