### PR TITLE
Implement schema conversion to returned docs and general improvements

### DIFF
--- a/lnx-engine/search-index/src/helpers.rs
+++ b/lnx-engine/search-index/src/helpers.rs
@@ -15,6 +15,12 @@ pub(crate) trait Validate {
     }
 }
 
+pub(crate) trait Calculated {
+    fn calculate_once(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
 pub(crate) trait AsScore {
     fn as_score(&self) -> Option<f32> {
         None

--- a/lnx-engine/search-index/src/helpers.rs
+++ b/lnx-engine/search-index/src/helpers.rs
@@ -16,9 +16,7 @@ pub(crate) trait Validate {
 }
 
 pub(crate) trait Calculated {
-    fn calculate_once(&mut self) -> Result<()> {
-        Ok(())
-    }
+    fn calculate_once(&mut self) -> Result<()>;
 }
 
 pub(crate) trait AsScore {

--- a/lnx-engine/search-index/src/index.rs
+++ b/lnx-engine/search-index/src/index.rs
@@ -1832,7 +1832,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn search_term_expect_ok() -> Result<()> {
+    async fn search_term_with_single_field_expect_ok() -> Result<()> {
         init_state();
 
         let index = get_basic_index(false).await?;
@@ -1841,6 +1841,98 @@ mod tests {
         let query: QueryPayload = serde_json::from_value(serde_json::json!({
             "query": {
                 "term": {"ctx": "man", "fields": "title"},
+            },
+        }))?;
+
+        let results = index.search(query).await.map_err(|e| {
+            eprintln!("{:?}", e);
+            e
+        });
+        assert!(results.is_ok());
+        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn search_term_with_single_field_and_boost_expect_ok() -> Result<()> {
+        init_state();
+
+        let index = get_basic_index(false).await?;
+        add_documents(&index).await?;
+
+        let query: QueryPayload = serde_json::from_value(serde_json::json!({
+            "query": {
+                "term": {"ctx": "man", "fields": "title", "boost": 1.0},
+            },
+        }))?;
+
+        let results = index.search(query).await.map_err(|e| {
+            eprintln!("{:?}", e);
+            e
+        });
+        assert!(results.is_ok());
+        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn search_term_with_multi_fields_expect_ok() -> Result<()> {
+        init_state();
+
+        let index = get_basic_index(false).await?;
+        add_documents(&index).await?;
+
+        let query: QueryPayload = serde_json::from_value(serde_json::json!({
+            "query": {
+                "term": {"ctx": "man", "fields": ["title", "description"]},
+            },
+        }))?;
+
+        let results = index.search(query).await.map_err(|e| {
+            eprintln!("{:?}", e);
+            e
+        });
+        assert!(results.is_ok());
+        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn search_term_with_multi_fields_and_boost_expect_ok() -> Result<()> {
+        init_state();
+
+        let index = get_basic_index(false).await?;
+        add_documents(&index).await?;
+
+        let query: QueryPayload = serde_json::from_value(serde_json::json!({
+            "query": {
+                "term": {"ctx": "man", "fields": {"title": 2.0, "description": 1.0}},
+            },
+        }))?;
+
+        let results = index.search(query).await.map_err(|e| {
+            eprintln!("{:?}", e);
+            e
+        });
+        assert!(results.is_ok());
+        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn search_term_with_default_fields_expect_ok() -> Result<()> {
+        init_state();
+
+        let index = get_basic_index(false).await?;
+        add_documents(&index).await?;
+
+        let query: QueryPayload = serde_json::from_value(serde_json::json!({
+            "query": {
+                "term": {"ctx": "man"},
             },
         }))?;
 

--- a/lnx-engine/search-index/src/index.rs
+++ b/lnx-engine/search-index/src/index.rs
@@ -316,6 +316,7 @@ impl InternalIndex {
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
+    use crate::helpers::Calculated;
 
     use super::*;
     use crate::structures::{DocumentValue, IndexDeclaration};
@@ -326,7 +327,8 @@ mod tests {
     }
 
     async fn get_index_with(value: serde_json::Value) -> Result<Index> {
-        let dec: IndexDeclaration = serde_json::from_value(value)?;
+        let mut dec: IndexDeclaration = serde_json::from_value(value)?;
+        dec.calculate_once()?;
 
         let res = dec.create_context()?;
         Index::create(res).await

--- a/lnx-engine/search-index/src/index.rs
+++ b/lnx-engine/search-index/src/index.rs
@@ -1179,7 +1179,11 @@ mod tests {
         .await
     }
 
-    async fn get_index_with_required_multi_fields(fast_fuzzy: bool, multi_title: bool, multi_description: bool) -> Result<Index> {
+    async fn get_index_with_required_multi_fields(
+        fast_fuzzy: bool,
+        multi_title: bool,
+        multi_description: bool,
+    ) -> Result<Index> {
         get_index_with(serde_json::json!({
             "name": "basic_test_index",
 

--- a/lnx-engine/search-index/src/index.rs
+++ b/lnx-engine/search-index/src/index.rs
@@ -1974,29 +1974,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn search_term_with_single_field_and_boost_expect_ok() -> Result<()> {
-        init_state();
-
-        let index = get_basic_index(false).await?;
-        add_documents(&index).await?;
-
-        let query: QueryPayload = serde_json::from_value(serde_json::json!({
-            "query": {
-                "term": {"ctx": "man", "fields": "title", "boost": 1.0},
-            },
-        }))?;
-
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
-
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn search_term_with_multi_fields_expect_ok() -> Result<()> {
         init_state();
 

--- a/lnx-engine/search-index/src/index.rs
+++ b/lnx-engine/search-index/src/index.rs
@@ -1843,23 +1843,15 @@ mod tests {
             },
         }))?;
 
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), NUM_DOCS);
 
         let query: QueryPayload = serde_json::from_value(serde_json::json!({
             "query": "Man",
         }))?;
 
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), NUM_DOCS);
 
         Ok(())
     }
@@ -1877,13 +1869,8 @@ mod tests {
             },
         }))?;
 
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), NUM_DOCS);
 
         Ok(())
     }
@@ -1901,13 +1888,8 @@ mod tests {
             },
         }))?;
 
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), NUM_DOCS);
 
         Ok(())
     }
@@ -1925,12 +1907,8 @@ mod tests {
             },
         }))?;
 
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), NUM_DOCS);
 
         let results = results.unwrap();
         let doc_id = results.hits[0].document_id;
@@ -1940,12 +1918,9 @@ mod tests {
                 "more-like-this": {"ctx": doc_id},
             },
         }))?;
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), NUM_DOCS);
 
         Ok(())
     }
@@ -1963,12 +1938,8 @@ mod tests {
             },
         }))?;
 
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), NUM_DOCS);
 
         Ok(())
     }
@@ -1986,12 +1957,8 @@ mod tests {
             },
         }))?;
 
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), NUM_DOCS);
 
         Ok(())
     }
@@ -2009,12 +1976,8 @@ mod tests {
             },
         }))?;
 
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), NUM_DOCS);
 
         Ok(())
     }
@@ -2032,12 +1995,8 @@ mod tests {
             },
         }))?;
 
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), NUM_DOCS);
 
         Ok(())
     }
@@ -2090,13 +2049,8 @@ mod tests {
             ],
         }))?;
 
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), 1);
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), 1);
 
         Ok(())
     }

--- a/lnx-engine/search-index/src/index.rs
+++ b/lnx-engine/search-index/src/index.rs
@@ -1763,7 +1763,6 @@ mod tests {
             e
         });
 
-        println!("{:?}", &results);
         assert!(results.is_ok());
         assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
 
@@ -1787,7 +1786,7 @@ mod tests {
             eprintln!("{:?}", e);
             e
         });
-        println!("{:?}", &results);
+
         assert!(results.is_ok());
         assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
 
@@ -1868,12 +1867,8 @@ mod tests {
             },
         }))?;
 
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), NUM_DOCS);
 
         let query: QueryPayload = serde_json::from_value(serde_json::json!({
             "query": {
@@ -1881,12 +1876,8 @@ mod tests {
             },
         }))?;
 
-        let results = index.search(query).await.map_err(|e| {
-            eprintln!("{:?}", e);
-            e
-        });
-        assert!(results.is_ok());
-        assert_eq!(results.as_ref().unwrap().hits.len(), 2);
+        let results = index.search(query).await?;
+        assert_eq!(results.hits.len(), 2);
 
         Ok(())
     }
@@ -1916,7 +1907,6 @@ mod tests {
             e
         });
 
-        println!("{:?}", &results);
         assert!(results.is_ok());
         assert_eq!(results.as_ref().unwrap().hits.len(), 1);
 

--- a/lnx-engine/search-index/src/index.rs
+++ b/lnx-engine/search-index/src/index.rs
@@ -316,7 +316,6 @@ impl InternalIndex {
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
-    use crate::helpers::Calculated;
 
     use super::*;
     use crate::structures::{DocumentValue, IndexDeclaration};
@@ -327,8 +326,7 @@ mod tests {
     }
 
     async fn get_index_with(value: serde_json::Value) -> Result<Index> {
-        let mut dec: IndexDeclaration = serde_json::from_value(value)?;
-        dec.calculate_once()?;
+        let dec: IndexDeclaration = serde_json::from_value(value)?;
 
         let res = dec.create_context()?;
         Index::create(res).await
@@ -987,7 +985,7 @@ mod tests {
                    "type": "u64",
                    "stored": true,
                    "indexed": true,
-                   "fast": "single"
+                   "fast": true
                 },
             },
 
@@ -1764,6 +1762,8 @@ mod tests {
             eprintln!("{:?}", e);
             e
         });
+
+        println!("{:?}", &results);
         assert!(results.is_ok());
         assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
 
@@ -1787,6 +1787,7 @@ mod tests {
             eprintln!("{:?}", e);
             e
         });
+        println!("{:?}", &results);
         assert!(results.is_ok());
         assert_eq!(results.as_ref().unwrap().hits.len(), NUM_DOCS);
 
@@ -1910,11 +1911,12 @@ mod tests {
             ],
         }))?;
 
-        let results = index.search(query).await
-            .map_err(|e| {
-                eprintln!("{:?}", e);
-                e
-            });
+        let results = index.search(query).await.map_err(|e| {
+            eprintln!("{:?}", e);
+            e
+        });
+
+        println!("{:?}", &results);
         assert!(results.is_ok());
         assert_eq!(results.as_ref().unwrap().hits.len(), 1);
 

--- a/lnx-engine/search-index/src/index.rs
+++ b/lnx-engine/search-index/src/index.rs
@@ -1910,7 +1910,6 @@ mod tests {
         let results = index.search(query).await?;
         assert_eq!(results.hits.len(), NUM_DOCS);
 
-        let results = results.unwrap();
         let doc_id = results.hits[0].document_id;
 
         let query: QueryPayload = serde_json::from_value(serde_json::json!({

--- a/lnx-engine/search-index/src/lib.rs
+++ b/lnx-engine/search-index/src/lib.rs
@@ -14,6 +14,7 @@ mod stop_words;
 mod storage;
 pub mod structures;
 mod writer;
+mod schema;
 
 pub use helpers::cr32_hash;
 pub use index::Index;

--- a/lnx-engine/search-index/src/lib.rs
+++ b/lnx-engine/search-index/src/lib.rs
@@ -10,11 +10,11 @@ mod helpers;
 mod index;
 mod query;
 mod reader;
+mod schema;
 mod stop_words;
 mod storage;
 pub mod structures;
 mod writer;
-mod schema;
 
 pub use helpers::cr32_hash;
 pub use index::Index;

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -506,7 +506,10 @@ impl QueryBuilder {
                 let term = Term::from_field_text(*field, search_term);
 
                 let query: Box<dyn Query> = if self.ctx.use_fast_fuzzy {
-                    Box::new(TermQuery::new(term, IndexRecordOption::WithFreqs))
+                    Box::new(TermQuery::new(
+                        term,
+                        IndexRecordOption::WithFreqsAndPositions,
+                    ))
                 } else {
                     let edit_distance = if search_term.len() >= cfg.min_length_distance2
                     {
@@ -517,6 +520,10 @@ impl QueryBuilder {
                         0
                     };
 
+                    println!(
+                        "{} - d{} - {}",
+                        search_term, edit_distance, !cfg.transposition_costs_two
+                    );
                     Box::new(FuzzyTermQuery::new_prefix(
                         term,
                         edit_distance,

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -240,10 +240,8 @@ pub enum FieldSelector {
     /// One or more fields to search in.
     Multi(Vec<String>),
 
-    /// A single field to search in.
-    SingleWithBoost { field: String, boost: Score },
-
-    /// One or more fields to search in.
+    /// One or more fields to search in each with their own
+    /// applied boost.
     MultiWithBoost(HashMap<String, Score>),
 
     /// Search in the fields defined by the `search_fields`

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -628,6 +628,8 @@ impl QueryBuilder {
     ) -> Result<Box<dyn Query>> {
         use tantivy::query::Occur;
 
+        dbg!(&value, &field);
+
         let fields = {
             match field {
                 FieldSelector::Single(field) => {
@@ -650,7 +652,7 @@ impl QueryBuilder {
             let term = convert_to_term(value.clone(), field, entry)?;
 
             let query = TermQuery::new(term, IndexRecordOption::Basic);
-            queries.push((Occur::Must, Box::new(query)));
+            queries.push((Occur::Should, Box::new(query)));
         }
 
         Ok(Box::new(BooleanQuery::new(queries)))

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -540,10 +540,6 @@ impl QueryBuilder {
                         0
                     };
 
-                    println!(
-                        "{} - d{} - {}",
-                        search_term, edit_distance, !cfg.transposition_costs_two
-                    );
                     Box::new(FuzzyTermQuery::new_prefix(
                         term,
                         edit_distance,

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -579,7 +579,6 @@ impl QueryBuilder {
         Ok(query)
     }
 
-    #[allow(clippy::too_many_arguments)]
     /// Makes a new query that matches documents that are similar to a
     /// given reference document.
     ///

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -241,7 +241,7 @@ pub enum FieldSelector {
     Multi(Vec<String>),
 
     /// One or more fields to search in each with their own
-    /// applied boost.
+    /// applied boost factor.
     MultiWithBoost(HashMap<String, Score>),
 
     /// Search in the fields defined by the `search_fields`

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -486,6 +486,13 @@ impl QueryBuilder {
         value: DocumentValue,
         cfg: FuzzyConfig,
     ) -> Result<Box<dyn Query>> {
+        if self.ctx.fuzzy_search_fields.is_empty() {
+            return Err(anyhow!(
+                "no string/text fields have been marked as search fields, \
+                because of this fuzzy search has been disabled"
+            ))
+        }
+
         use tantivy::query::Occur;
 
         let mut query = value.as_string();

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -490,7 +490,7 @@ impl QueryBuilder {
             return Err(anyhow!(
                 "no string/text fields have been marked as search fields, \
                 because of this fuzzy search has been disabled"
-            ))
+            ));
         }
 
         use tantivy::query::Occur;

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -486,14 +486,14 @@ impl QueryBuilder {
         value: DocumentValue,
         cfg: FuzzyConfig,
     ) -> Result<Box<dyn Query>> {
+        use tantivy::query::Occur;
+
         if self.ctx.fuzzy_search_fields.is_empty() {
             return Err(anyhow!(
                 "no string/text fields have been marked as search fields, \
                 because of this fuzzy search has been disabled"
             ));
         }
-
-        use tantivy::query::Occur;
 
         let mut query = value.as_string();
         if query.is_empty() {

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -649,9 +649,6 @@ impl QueryBuilder {
                 FieldSelector::Single(field) => {
                     vec![(self.get_searchable_field(&field)?, 1.0)]
                 },
-                FieldSelector::SingleWithBoost { field, boost } => {
-                    vec![(self.get_searchable_field(&field)?, boost)]
-                },
                 FieldSelector::Multi(fields) => {
                     if fields.is_empty() {
                         return Err(anyhow!(

--- a/lnx-engine/search-index/src/reader.rs
+++ b/lnx-engine/search-index/src/reader.rs
@@ -168,7 +168,7 @@ fn process_search<S: AsScore>(
                 ctx,
                 doc_id,
                 doc,
-                ratio.as_score()
+                ratio.as_score(),
             ));
         } else {
             return Err(Error::msg("document has been missed labeled (missing identifier tag), the dataset is invalid"));
@@ -415,7 +415,7 @@ impl Reader {
             &self.schema_ctx,
             id,
             document,
-            Some(1.0)
+            Some(1.0),
         ))
     }
 
@@ -445,7 +445,14 @@ impl Reader {
 
                 let (hits, count) = if let Some(Some(field)) = order_by {
                     order_or_sort(
-                        sort, field, &query, ctx.as_ref(), schema, &searcher, collector, executor,
+                        sort,
+                        field,
+                        &query,
+                        ctx.as_ref(),
+                        schema,
+                        &searcher,
+                        collector,
+                        executor,
                     )?
                 } else {
                     let (out, count) = searcher.search_with_executor(

--- a/lnx-engine/search-index/src/reader.rs
+++ b/lnx-engine/search-index/src/reader.rs
@@ -182,7 +182,7 @@ fn process_search<S: AsScore>(
 ///
 /// This function is super messy just because of all the type inference
 /// so any contributions to clean this up would be very appreciated.
-fn order_or_sort(
+fn order_and_sort(
     sort: Sort,
     field: Field,
     query: &dyn Query,
@@ -444,7 +444,7 @@ impl Reader {
                 let order_by = order_by.map(|v| schema.get_field(&v));
 
                 let (hits, count) = if let Some(Some(field)) = order_by {
-                    order_or_sort(
+                    order_and_sort(
                         sort,
                         field,
                         &query,

--- a/lnx-engine/search-index/src/reader.rs
+++ b/lnx-engine/search-index/src/reader.rs
@@ -197,7 +197,9 @@ fn order_and_sort(
         .contains(schema.get_field_name(field));
 
     if is_multi_value {
-        return Err(anyhow!("multi-value fields cannot be used to sort results see issue #70"));
+        return Err(anyhow!(
+            "multi-value fields cannot be used to sort results see issue #70"
+        ));
     }
 
     let field_type = schema.get_field_entry(field).field_type();

--- a/lnx-engine/search-index/src/reader.rs
+++ b/lnx-engine/search-index/src/reader.rs
@@ -3,7 +3,7 @@ use std::cmp::Reverse;
 use std::sync::Arc;
 
 use aexecutor::SearcherExecutorPool;
-use anyhow::{Error, Result};
+use anyhow::{anyhow, Error, Result};
 use serde::{Deserialize, Serialize};
 use tantivy::collector::{Count, TopDocs};
 use tantivy::fastfield::FastFieldReader;
@@ -192,6 +192,13 @@ fn order_and_sort(
     collector: TopDocs,
     executor: &Executor,
 ) -> Result<(Vec<DocumentHit>, usize)> {
+    if ctx
+        .multi_value_fields()
+        .contains(schema.get_field_name(field))
+    {
+        return Err(anyhow!("multi-value fields cannot be used to sort results"));
+    }
+
     let field_type = schema.get_field_entry(field).field_type();
     if let Sort::Desc = sort {
         return match field_type {

--- a/lnx-engine/search-index/src/reader.rs
+++ b/lnx-engine/search-index/src/reader.rs
@@ -182,6 +182,7 @@ fn process_search<S: AsScore>(
 ///
 /// This function is super messy just because of all the type inference
 /// so any contributions to clean this up would be very appreciated.
+#[allow(clippy::too_many_arguments)]
 fn order_and_sort(
     sort: Sort,
     field: Field,

--- a/lnx-engine/search-index/src/reader.rs
+++ b/lnx-engine/search-index/src/reader.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::sync::Arc;
 
@@ -305,7 +306,7 @@ fn order_or_sort(
 /// Each index should only have on `Reader` instance.
 #[derive(Clone)]
 pub(crate) struct Reader {
-    index_name: Arc<String>,
+    index_name: Cow<'static, str>,
 
     /// The executor pool.
     pool: crate::ReaderExecutor,
@@ -358,7 +359,7 @@ impl Reader {
         );
 
         Ok(Self {
-            index_name: Arc::new(ctx.name()),
+            index_name: Cow::Owned(ctx.name()),
             pool,
             query_handler: Arc::new(query_handler),
         })

--- a/lnx-engine/search-index/src/reader.rs
+++ b/lnx-engine/search-index/src/reader.rs
@@ -192,11 +192,12 @@ fn order_and_sort(
     collector: TopDocs,
     executor: &Executor,
 ) -> Result<(Vec<DocumentHit>, usize)> {
-    if ctx
+    let is_multi_value = ctx
         .multi_value_fields()
-        .contains(schema.get_field_name(field))
-    {
-        return Err(anyhow!("multi-value fields cannot be used to sort results"));
+        .contains(schema.get_field_name(field));
+
+    if is_multi_value {
+        return Err(anyhow!("multi-value fields cannot be used to sort results see issue #70"));
     }
 
     let field_type = schema.get_field_entry(field).field_type();

--- a/lnx-engine/search-index/src/schema.rs
+++ b/lnx-engine/search-index/src/schema.rs
@@ -2,8 +2,22 @@ use std::iter::FromIterator;
 
 use anyhow::{anyhow, Error, Result};
 use hashbrown::{HashMap, HashSet};
-use serde::{Serialize, Deserialize};
-use tantivy::schema::{Cardinality, FacetOptions, FAST, Field, FieldType, INDEXED, IndexRecordOption, IntOptions, Schema, SchemaBuilder, STORED, TextFieldIndexing, TextOptions};
+use serde::{Deserialize, Serialize};
+use tantivy::schema::{
+    Cardinality,
+    FacetOptions,
+    Field,
+    FieldType,
+    IndexRecordOption,
+    IntOptions,
+    Schema,
+    SchemaBuilder,
+    TextFieldIndexing,
+    TextOptions,
+    FAST,
+    INDEXED,
+    STORED,
+};
 use tantivy::Score;
 
 use crate::helpers::{Calculated, Validate};
@@ -13,7 +27,6 @@ pub static PRIMARY_KEY: &str = "_id";
 fn default_to_true() -> bool {
     true
 }
-
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SchemaContext {
@@ -88,27 +101,21 @@ impl Validate for SchemaContext {
 impl Calculated for SchemaContext {
     fn calculate_once(&mut self) -> Result<()> {
         self.required_fields = HashSet::from_iter(
-            self.fields.iter()
-                .filter_map(|(name, info)|
-                    if info.is_required() {
-                        Some(name)
-                    } else {
-                        None
-                    }
+            self.fields
+                .iter()
+                .filter_map(
+                    |(name, info)| if info.is_required() { Some(name) } else { None },
                 )
-                .cloned()
+                .cloned(),
         );
 
         self.multi_value_fields = HashSet::from_iter(
-            self.fields.iter()
-                .filter_map(|(name, info)|
-                    if info.is_multi() {
-                        Some(name)
-                    } else {
-                        None
-                    }
+            self.fields
+                .iter()
+                .filter_map(
+                    |(name, info)| if info.is_multi() { Some(name) } else { None },
                 )
-                .cloned()
+                .cloned(),
         );
 
         Ok(())
@@ -140,7 +147,6 @@ impl SchemaContext {
         &self.multi_value_fields
     }
 
-
     /// Checks and asserts that the fields defined by Tantivy are also the same set of fields
     /// defined in the schema.
     ///
@@ -157,8 +163,10 @@ impl SchemaContext {
             .map(|(f, _)| existing.get_field_name(f))
             .collect();
 
-        let defined_fields_set: HashSet<&str> = HashSet::from_iter(defined_fields.into_iter());
-        let existing_fields_set: HashSet<&str> = HashSet::from_iter(existing_fields.into_iter());
+        let defined_fields_set: HashSet<&str> =
+            HashSet::from_iter(defined_fields.into_iter());
+        let existing_fields_set: HashSet<&str> =
+            HashSet::from_iter(existing_fields.into_iter());
 
         let union: Vec<&str> = defined_fields_set
             .difference(&existing_fields_set)
@@ -358,7 +366,11 @@ impl BaseFieldOptions {
 
     fn opts_as_text(&self) -> TextOptions {
         let raw = self.as_raw_opts();
-        raw.set_indexing_options(TextFieldIndexing::default().set_tokenizer("raw"))
+        raw.set_indexing_options(
+            TextFieldIndexing::default()
+                .set_fieldnorms(true)
+                .set_tokenizer("raw"),
+        )
     }
 
     fn opts_as_string(&self) -> TextOptions {
@@ -366,6 +378,7 @@ impl BaseFieldOptions {
         raw.set_indexing_options(
             TextFieldIndexing::default()
                 .set_tokenizer("default")
+                .set_fieldnorms(true)
                 .set_index_option(IndexRecordOption::WithFreqsAndPositions),
         )
     }

--- a/lnx-engine/search-index/src/schema.rs
+++ b/lnx-engine/search-index/src/schema.rs
@@ -1,0 +1,402 @@
+use anyhow::{anyhow, Error, Result};
+use hashbrown::HashMap;
+use serde::{Serialize, Deserialize};
+use tantivy::schema::{Cardinality, FacetOptions, FAST, Field, FieldType, INDEXED, IndexRecordOption, IntOptions, Schema, SchemaBuilder, STORED, TextFieldIndexing, TextOptions};
+use tantivy::Score;
+use crate::helpers::Validate;
+
+pub static PRIMARY_KEY: &str = "_id";
+
+fn default_to_true() -> bool {
+    true
+}
+
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchemaContext {
+    /// The index's fields.
+    ///
+    /// Document entries will be implicitly converted into the index's schema types
+    /// if they need to be.
+    fields: HashMap<String, FieldDeclaration>,
+
+    /// The fields what are actually searched via tantivy.
+    ///
+    /// These values need to either be a fast field (ints) or TEXT.
+    search_fields: Vec<String>,
+
+    /// A set of fields to boost by a given factor.
+    #[serde(default)]
+    boost_fields: HashMap<String, Score>,
+}
+
+impl Validate for SchemaContext {
+    fn validate(&self) -> Result<()> {
+        if self.search_fields.is_empty() {
+            return Err(Error::msg(
+                "at least one indexed field must be given to search.",
+            ));
+        }
+
+        {
+            let mut rejected_fields = vec![];
+            for field_name in self.boost_fields.keys() {
+                if !self.has_field(field_name) {
+                    rejected_fields.push(field_name.to_string());
+                }
+            }
+
+            if !rejected_fields.is_empty() {
+                return Err(anyhow!(
+                "key 'boost_fields' contain {} fields that are not defined in the schema: {}",
+                rejected_fields.len(),
+                rejected_fields.join(", "),
+            ));
+            }
+        }
+
+        {
+            let mut rejected_fields = vec![];
+            for field_name in self.search_fields.iter() {
+                if !self.has_field(field_name) {
+                    rejected_fields.push(field_name.to_string());
+                }
+            }
+
+            if !rejected_fields.is_empty() {
+                return Err(anyhow!(
+                "key 'search_fields' contain {} fields that are not defined in the schema: {}",
+                rejected_fields.len(),
+                rejected_fields.join(", "),
+            ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl SchemaContext {
+    pub fn has_field(&self, field_name: &str) -> bool {
+        self.fields.contains_key(field_name)
+    }
+
+    #[inline]
+    pub fn boost_fields(&self) -> &HashMap<String, Score> {
+        &self.boost_fields
+    }
+
+    /// Validates all search fields so that they're all indexed.
+    ///
+    /// If the search fields contain any fields that are not indexed,
+    /// the system will list all rejected fields in a Error.
+    /// Or if any fields are not text.
+    pub fn verify_search_fields(&self, schema: &Schema) -> Result<()> {
+        let mut reject = vec![];
+
+        for (_, entry) in schema.fields() {
+            let name = entry.name().to_string();
+            if !self.search_fields.contains(&name) {
+                continue;
+            }
+
+            match entry.field_type() {
+                FieldType::Str(_) => {},
+                _ => {
+                    return Err(anyhow!(
+                        "search field '{}' is not a text / string field type.",
+                        &name,
+                    ))
+                },
+            }
+
+            if !entry.is_indexed() {
+                reject.push(name)
+            }
+        }
+
+        if reject.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "the given search fields contain non-indexed fields, \
+                 fields cannot be searched without being index. Invalid fields: {}",
+                reject.join(", ")
+            ))
+        }
+    }
+
+    /// Gets all fields that exist in the schema and are marked as search
+    /// fields.
+    pub fn get_search_fields(&self, schema: &Schema) -> Vec<Field> {
+        let mut search_fields = vec![];
+
+        for (field, entry) in schema.fields() {
+            if entry.name() == PRIMARY_KEY {
+                continue;
+            }
+
+            // if it's not searchable, it's pointless having it be searched.
+            if !entry.is_indexed() {
+                continue;
+            }
+
+            if !self.search_fields.contains(&entry.name().to_string()) {
+                continue;
+            }
+
+            if let FieldType::Str(_) = entry.field_type() {
+                search_fields.push(field);
+            }
+        }
+
+        search_fields
+    }
+
+    /// Gets all TEXT and STRING fields that are marked at search fields.
+    ///
+    /// If the index uses fast-fuzzy this uses the pre-computed fields.
+    pub fn get_fuzzy_search_fields(&self, schema: &Schema) -> Vec<Field> {
+        let mut search_fields = vec![];
+
+        for (field, entry) in schema.fields() {
+            // if it's not searchable, it's pointless having it be searched.
+            if !entry.is_indexed() {
+                continue;
+            }
+
+            let name = entry.name().to_string();
+            if !self.search_fields.contains(&name) {
+                continue;
+            };
+
+            if let FieldType::Str(_) = entry.field_type() {
+                search_fields.push(field);
+            }
+        }
+
+        search_fields
+    }
+
+    /// Generates a new schema from the given fields.
+    pub fn as_tantivy_schema(&self) -> tantivy::schema::Schema {
+        let mut schema = SchemaBuilder::new();
+        schema.add_u64_field(PRIMARY_KEY, FAST | STORED | INDEXED);
+
+        for (field, details) in self.fields.iter() {
+            if field == PRIMARY_KEY {
+                warn!(
+                    "{} is a reserved field name due to being a primary key",
+                    PRIMARY_KEY
+                );
+                continue;
+            }
+
+            match details {
+                FieldDeclaration::U64 { opts } => {
+                    schema.add_u64_field(field, opts.clone());
+                },
+                FieldDeclaration::I64 { opts } => {
+                    schema.add_i64_field(field, opts.clone());
+                },
+                FieldDeclaration::F64 { opts } => {
+                    schema.add_f64_field(field, opts.clone());
+                },
+                FieldDeclaration::Date { opts } => {
+                    schema.add_date_field(field, opts.clone());
+                },
+                FieldDeclaration::Facet { opts } => {
+                    schema.add_facet_field(field, opts.clone());
+                },
+                FieldDeclaration::Text { opts } => {
+                    schema.add_text_field(field, opts.opts_as_text());
+                },
+                FieldDeclaration::String { opts } => {
+                    schema.add_text_field(field, opts.opts_as_string());
+                },
+            }
+        }
+
+        schema.build()
+    }
+}
+
+/// The base options every field can have.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+pub struct BaseFieldOptions {
+    /// If the value should be compressed and stored.
+    ///
+    /// Any value that has stored set to true will have the field
+    /// value returned when searching.
+    ///
+    /// Defaults to true.
+    #[serde(default = "default_to_true")]
+    stored: bool,
+
+    /// If the field is multi-value.
+    #[serde(default)]
+    multi: bool,
+}
+
+impl Into<FacetOptions> for BaseFieldOptions {
+    fn into(self) -> FacetOptions {
+        let mut opts = FacetOptions::default();
+
+        if self.stored {
+            opts = opts.set_stored();
+        }
+
+        opts
+    }
+}
+
+impl BaseFieldOptions {
+    fn as_raw_opts(&self) -> TextOptions {
+        let mut opts = TextOptions::default();
+
+        if self.stored {
+            opts = opts.set_stored();
+        }
+
+        opts
+    }
+
+    fn opts_as_text(&self) -> TextOptions {
+        let raw = self.as_raw_opts();
+        raw.set_indexing_options(TextFieldIndexing::default().set_tokenizer("raw"))
+    }
+
+    fn opts_as_string(&self) -> TextOptions {
+        let raw = self.as_raw_opts();
+        raw.set_indexing_options(
+            TextFieldIndexing::default()
+                .set_tokenizer("default")
+                .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+        )
+    }
+}
+
+impl Into<TextOptions> for BaseFieldOptions {
+    fn into(self) -> TextOptions {
+        let mut opts = TextOptions::default();
+
+        if self.stored {
+            opts = opts.set_stored();
+        }
+
+        opts
+    }
+}
+
+/// A set of field options that takes into account if a field is
+/// multi-value or not in order to determine the fast-field cardinality.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+pub struct CalculatedIntOptions {
+    /// Should the integer be indexed to be searched?
+    #[serde(default)]
+    indexed: bool,
+
+    /// Should fieldnorms be used?
+    ///
+    /// This is only relevant if `indexed = true`.
+    /// By default this is `indexed` if left empty.
+    fieldnorms: Option<bool>,
+
+    /// Is the field a fast field?.
+    ///
+    /// Fast fields have a similar lookup time to an array.
+    #[serde(default)]
+    fast: bool,
+
+    #[serde(flatten)]
+    base: BaseFieldOptions,
+}
+
+impl Into<IntOptions> for CalculatedIntOptions {
+    fn into(self) -> IntOptions {
+        let mut opts = IntOptions::default();
+
+        if self.indexed {
+            opts = opts.set_indexed();
+        }
+
+        if self.base.stored {
+            opts = opts.set_stored();
+        }
+
+        if self.fieldnorms.unwrap_or(self.indexed) {
+            opts = opts.set_fieldnorm();
+        }
+
+        if self.fast {
+            let cardinality = if self.base.multi {
+                Cardinality::MultiValues
+            } else {
+                Cardinality::SingleValue
+            };
+
+            opts = opts.set_fast(cardinality);
+        }
+
+        opts
+    }
+}
+
+/// A declared schema field type.
+///
+/// Each field has a set of relevant options as specified
+/// by the tantivy docs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[serde(tag = "type")]
+pub enum FieldDeclaration {
+    /// A f64 field with given options
+    F64 {
+        #[serde(flatten)]
+        opts: CalculatedIntOptions,
+    },
+
+    /// A u64 field with given options.
+    U64 {
+        #[serde(flatten)]
+        opts: CalculatedIntOptions,
+    },
+
+    /// A I64 field with given options.
+    I64 {
+        #[serde(flatten)]
+        opts: CalculatedIntOptions,
+    },
+
+    /// A Datetime<Utc> field with given options.
+    ///
+    /// This is treated as a u64 integer timestamp.
+    Date {
+        #[serde(flatten)]
+        opts: CalculatedIntOptions,
+    },
+
+    /// A string field with given options.
+    ///
+    /// This will be tokenized.
+    Text {
+        #[serde(flatten)]
+        opts: BaseFieldOptions,
+    },
+
+    /// A string field with given options.
+    ///
+    /// This wont be tokenized.
+    String {
+        #[serde(flatten)]
+        opts: BaseFieldOptions,
+    },
+
+    /// A facet field.
+    ///
+    /// This is typically represented as a path e.g. `videos/moves/ironman`
+    Facet {
+        #[serde(flatten)]
+        opts: BaseFieldOptions,
+    },
+}

--- a/lnx-engine/search-index/src/schema.rs
+++ b/lnx-engine/search-index/src/schema.rs
@@ -88,6 +88,13 @@ impl Validate for SchemaContext {
 
         Ok(())
     }
+
+    fn validate_with_schema(&self, schema: &Schema) -> Result<()> {
+        self.verify_search_fields(schema)?;
+        self.assert_existing_schema_matches(schema)?;
+
+        Ok(())
+    }
 }
 
 impl Calculated for SchemaContext {
@@ -196,7 +203,7 @@ impl SchemaContext {
     /// If the search fields contain any fields that are not indexed,
     /// the system will list all rejected fields in a Error.
     /// Or if any fields are not text.
-    pub fn verify_search_fields(&self, schema: &Schema) -> Result<()> {
+    fn verify_search_fields(&self, schema: &Schema) -> Result<()> {
         let mut reject = vec![];
 
         for (_, entry) in schema.fields() {

--- a/lnx-engine/search-index/src/structures.rs
+++ b/lnx-engine/search-index/src/structures.rs
@@ -151,6 +151,7 @@ impl IndexDeclaration {
         }?;
 
         let schema = index.schema();
+        self.schema_ctx.assert_existing_schema_matches(&schema)?;
         self.schema_ctx.verify_search_fields(&schema)?;
 
         let query_context = {
@@ -627,7 +628,7 @@ impl DocumentPayload {
         for (field_name, info) in ctx.fields() {
             let data = match self.0.remove(field_name) {
                 Some(data) => data,
-                None => if info.required() {
+                None => if info.is_required() {
                     return Err(anyhow!("missing a required field {:?}", field_name))
                 } else {
                     continue;

--- a/lnx-engine/search-index/src/structures.rs
+++ b/lnx-engine/search-index/src/structures.rs
@@ -156,8 +156,7 @@ impl IndexDeclaration {
         }?;
 
         let schema = index.schema();
-        schema_ctx.assert_existing_schema_matches(&schema)?;
-        schema_ctx.verify_search_fields(&schema)?;
+        schema_ctx.validate_with_schema(&schema)?;
 
         let query_context = {
             let default_fields = schema_ctx.get_search_fields(&schema);

--- a/lnx-engine/search-index/src/structures.rs
+++ b/lnx-engine/search-index/src/structures.rs
@@ -549,7 +549,7 @@ impl DocumentValueOptions {
     pub fn len(&self) -> usize {
         match self {
             Self::Single(_) => 1,
-            Self::Many(v) => v.len()
+            Self::Many(v) => v.len(),
         }
     }
 
@@ -646,15 +646,21 @@ impl DocumentPayload {
         for (field_name, info) in ctx.fields() {
             let data = match self.0.remove(field_name) {
                 Some(data) => {
-                     if info.is_required() & data.is_empty() {
-                        return Err(anyhow!("a required field ({:?}) must contain at least one value", field_name));
+                    if info.is_required() & data.is_empty() {
+                        return Err(anyhow!(
+                            "a required field ({:?}) must contain at least one value",
+                            field_name
+                        ));
                     }
 
                     data
                 },
                 None => {
                     if info.is_required() {
-                        return Err(anyhow!("missing a required field {:?}", field_name));
+                        return Err(anyhow!(
+                            "missing a required field {:?}",
+                            field_name
+                        ));
                     } else {
                         continue;
                     }
@@ -674,11 +680,15 @@ impl DocumentPayload {
                 DocumentValueOptions::Many(mut values) => {
                     if ctx.multi_value_fields().contains(field_name) {
                         for value in values {
-                            Self::add_value(field_name, field, field_type, value, &mut doc)?;
+                            Self::add_value(
+                                field_name, field, field_type, value, &mut doc,
+                            )?;
                         }
                     } else {
                         if let Some(value) = values.pop() {
-                            Self::add_value(field_name, field, field_type, value, &mut doc)?;
+                            Self::add_value(
+                                field_name, field, field_type, value, &mut doc,
+                            )?;
                         }
                     }
                 },
@@ -803,7 +813,6 @@ pub enum CompliantDocumentValue {
     Single(tantivy::schema::Value),
     Multi(Vec<tantivy::schema::Value>),
 }
-
 
 /// A individual document returned from the index.
 #[derive(Debug, Serialize)]

--- a/lnx-engine/search-index/src/structures.rs
+++ b/lnx-engine/search-index/src/structures.rs
@@ -633,7 +633,10 @@ impl DocumentPayload {
                 Some(data) => data,
                 None => {
                     if info.is_required() {
-                        return Err(anyhow!("missing a required field {:?}", field_name));
+                        return Err(anyhow!(
+                            "missing a required field {:?}",
+                            field_name
+                        ));
                     } else {
                         continue;
                     }

--- a/lnx-engine/search-index/src/writer.rs
+++ b/lnx-engine/search-index/src/writer.rs
@@ -15,6 +15,7 @@ use tokio::time::Duration;
 
 use crate::corrections::SymSpellCorrectionManager;
 use crate::helpers::{cr32_hash, Validate};
+use crate::schema::{SchemaContext, PRIMARY_KEY};
 use crate::stop_words::{PersistentStopWordManager, StopWordManager};
 use crate::storage::StorageBackend;
 use crate::structures::{
@@ -23,7 +24,6 @@ use crate::structures::{
     INDEX_STORAGE_SUB_PATH,
     ROOT_PATH,
 };
-use crate::schema::{PRIMARY_KEY, SchemaContext};
 use crate::DocumentId;
 
 type OpPayload = (WriterOp, Option<oneshot::Sender<Result<()>>>);

--- a/lnx-engine/search-index/src/writer.rs
+++ b/lnx-engine/search-index/src/writer.rs
@@ -21,9 +21,9 @@ use crate::structures::{
     DocumentPayload,
     IndexContext,
     INDEX_STORAGE_SUB_PATH,
-    PRIMARY_KEY,
     ROOT_PATH,
 };
+use crate::schema::PRIMARY_KEY;
 use crate::DocumentId;
 
 type OpPayload = (WriterOp, Option<oneshot::Sender<Result<()>>>);


### PR DESCRIPTION
Closes #67 

This adds the ability for a user to explicitly state in the schema if a field is multi-value or not.
If the field isn't multi-value the returned field will be unwrapped from it's array wrapper.