### PR TITLE
Fix: #78 commit error

### DIFF
--- a/lnx-engine/search-index/src/writer.rs
+++ b/lnx-engine/search-index/src/writer.rs
@@ -418,7 +418,7 @@ impl IndexWriterWorker {
                 let dict = match reader.term_dict(*field) {
                     Ok(dict) => dict,
                     Err(TantivyError::DataCorruption(_)) => continue,
-                    Err(e) => return Err(e.into())
+                    Err(e) => return Err(e.into()),
                 };
                 let mut stream = dict.stream()?;
 

--- a/lnx-engine/search-index/src/writer.rs
+++ b/lnx-engine/search-index/src/writer.rs
@@ -9,7 +9,7 @@ use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 use sysinfo::SystemExt;
 use tantivy::schema::{Field, Schema};
-use tantivy::{IndexWriter, Opstamp, Term};
+use tantivy::{IndexWriter, Opstamp, TantivyError, Term};
 use tokio::sync::oneshot;
 use tokio::time::Duration;
 
@@ -415,7 +415,11 @@ impl IndexWriterWorker {
         let mut map: HashMap<String, u32> = HashMap::new();
         for reader in searcher.segment_readers() {
             for field in self.fuzzy_fields.iter() {
-                let dict = reader.term_dict(*field)?;
+                let dict = match reader.term_dict(*field) {
+                    Ok(dict) => dict,
+                    Err(TantivyError::DataCorruption(_)) => continue,
+                    Err(e) => return Err(e.into())
+                };
                 let mut stream = dict.stream()?;
 
                 // We assume every term is a string, it wouldn't make sense for fuzzy fields


### PR DESCRIPTION
This closes #78  by ignoring fields if the term dictionary does not yet exist.

This bug was an unfortunate situation where you have an empty index and specify a search field that has yet to have any terms registered with it.