### PR TITLE
Removed the CRON job from Docker publish action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,8 +6,6 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '35 8 * * *'
   push:
     branches: [ master ]
     # Publish semver tags as releases.


### PR DESCRIPTION
Do we really need to have a cron job for the Docker publish action?