### PR TITLE
lnx-server: use mimalloc only on msvc.

### DIFF
--- a/lnx-server/Cargo.toml
+++ b/lnx-server/Cargo.toml
@@ -36,6 +36,6 @@ parking_lot = "0.11"
 rand = "0.8.4"
 
 # allocator
-mimalloc = { version = "*", default-features = false }
+mimalloc = { version = "*", default-features = false, optional = true }
 
 engine = { path = "../lnx-engine/engine" }

--- a/lnx-server/Cargo.toml
+++ b/lnx-server/Cargo.toml
@@ -36,6 +36,6 @@ parking_lot = "0.11"
 rand = "0.8.4"
 
 # allocator
-mimalloc = { version = "*", default-features = false, optional = true }
+mimalloc = { version = "*", default-features = false }
 
 engine = { path = "../lnx-engine/engine" }

--- a/lnx-server/src/main.rs
+++ b/lnx-server/src/main.rs
@@ -19,15 +19,15 @@ use clap::Parser;
 use engine::structures::{IndexDeclaration, ROOT_PATH};
 use engine::Engine;
 use hyper::Server;
-use mimalloc::MiMalloc;
 use routerify::RouterService;
 use tracing::Level;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 
+#[cfg(target_env = "msvc")]
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use crate::auth::AuthManager;
 use crate::snapshot::{create_snapshot, load_snapshot};


### PR DESCRIPTION
This PR adds a compiler attribute into lnx-server/main.rs to only use `mimalloc` in MSVC environments.