### PR TITLE
LNX-76: Add staggered search exectution 

### DIFF
--- a/lnx-engine/search-index/src/corrections.rs
+++ b/lnx-engine/search-index/src/corrections.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use hashbrown::HashMap;
-use symspell::{AsciiStringStrategy, SymSpell};
+use symspell::{AsciiStringStrategy, Suggestion, SymSpell, Verbosity};
 
 pub(crate) type SymSpellCorrectionManager = Arc<SymSpellManager>;
 
@@ -24,6 +24,10 @@ impl SymSpellManager {
     /// If the index does not have a set of frequencies this returns the original string.
     pub(crate) fn correct(&self, sentence: &str) -> String {
         self.sym.load().lookup_compound(sentence, 2)
+    }
+    
+    pub(crate) fn terms(&self, term: &str, dist: i64) -> Vec<Suggestion> {
+        self.sym.load().lookup(term, Verbosity::Top, dist)
     }
 
     /// Sets a custom symspell handler for the given index.

--- a/lnx-engine/search-index/src/corrections.rs
+++ b/lnx-engine/search-index/src/corrections.rs
@@ -25,7 +25,7 @@ impl SymSpellManager {
     pub(crate) fn correct(&self, sentence: &str) -> String {
         self.sym.load().lookup_compound(sentence, 2)
     }
-    
+
     pub(crate) fn terms(&self, term: &str, dist: i64) -> Vec<Suggestion> {
         self.sym.load().lookup(term, Verbosity::Top, dist)
     }

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -8,7 +8,17 @@ use serde::de::value::{MapAccessDeserializer, SeqAccessDeserializer};
 use serde::de::{MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 use tantivy::collector::TopDocs;
-use tantivy::query::{AllQuery, BooleanQuery, BoostQuery, EmptyQuery, FuzzyTermQuery, MoreLikeThisQuery, Query, QueryParser, TermQuery};
+use tantivy::query::{
+    AllQuery,
+    BooleanQuery,
+    BoostQuery,
+    EmptyQuery,
+    FuzzyTermQuery,
+    MoreLikeThisQuery,
+    Query,
+    QueryParser,
+    TermQuery,
+};
 use tantivy::schema::IndexRecordOption::WithFreqsAndPositions;
 use tantivy::schema::{
     Facet,
@@ -480,7 +490,7 @@ impl QueryBuilder {
         let single_stage = if !single_stage.is_empty() {
             Box::new(BooleanQuery::new(single_stage)) as Box<dyn Query>
         } else {
-            Box::new(AllQuery{}) as Box<dyn Query>
+            Box::new(AllQuery {}) as Box<dyn Query>
         };
 
         let mut secondary_stages = vec![];

--- a/lnx-engine/search-index/src/query.rs
+++ b/lnx-engine/search-index/src/query.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 use std::convert::TryInto;
 use std::sync::Arc;
-use std::time::Instant;
 
 use anyhow::{anyhow, Error, Result};
 use hashbrown::HashMap;

--- a/lnx-engine/search-index/src/reader.rs
+++ b/lnx-engine/search-index/src/reader.rs
@@ -224,7 +224,6 @@ macro_rules! execute_staged_search {
 
             Ok::<_, anyhow::Error>((results, count))
         } else {
-            info!("Got a baby!");
             let mut approx_count = 0;
             let mut past_addresses = HashSet::new();
             let mut result_addresses = vec![];

--- a/lnx-engine/search-index/src/reader.rs
+++ b/lnx-engine/search-index/src/reader.rs
@@ -224,6 +224,7 @@ macro_rules! execute_staged_search {
 
             Ok::<_, anyhow::Error>((results, count))
         } else {
+            info!("Got a baby!");
             let mut approx_count = 0;
             let mut past_addresses = HashSet::new();
             let mut result_addresses = vec![];
@@ -586,10 +587,12 @@ impl Reader {
                         executor,
                     )?
                 } else {
-                    let collector = TopDocs::with_limit(limit);
+                    let collector = TopDocs::with_limit(limit + offset);
                     let out: (Vec<(Score, DocAddress)>, usize) = execute_staged_search!(
                         queries, searcher, collector, executor, limit, offset
                     )?;
+
+
                     (
                         process_search(ctx.as_ref(), &searcher, schema, out.0)?,
                         out.1,

--- a/lnx-engine/search-index/src/reader.rs
+++ b/lnx-engine/search-index/src/reader.rs
@@ -591,7 +591,6 @@ impl Reader {
                         queries, searcher, collector, executor, limit, offset
                     )?;
 
-
                     (
                         process_search(ctx.as_ref(), &searcher, schema, out.0)?,
                         out.1,

--- a/lnx-engine/search-index/src/reader.rs
+++ b/lnx-engine/search-index/src/reader.rs
@@ -11,7 +11,19 @@ use tantivy::collector::{Count, TopDocs};
 use tantivy::fastfield::FastFieldReader;
 use tantivy::query::{BooleanQuery, Query, QueryClone, TermQuery};
 use tantivy::schema::{Field, FieldType, IndexRecordOption, Schema, Value};
-use tantivy::{DateTime, DocAddress, DocId, Executor, IndexReader, LeasedItem, ReloadPolicy, Score, Searcher, SegmentReader, Term};
+use tantivy::{
+    DateTime,
+    DocAddress,
+    DocId,
+    Executor,
+    IndexReader,
+    LeasedItem,
+    ReloadPolicy,
+    Score,
+    Searcher,
+    SegmentReader,
+    Term,
+};
 
 use crate::helpers::{AsScore, Validate};
 use crate::query::{DocumentId, QueryBuilder, QuerySelector};
@@ -145,12 +157,13 @@ fn order_and_search<R: AsScore + tantivy::fastfield::FastValue>(
             .search_with_executor(&primary_stage, &collector, executor)
             .map_err(Error::from)?;
 
-        let results = result_addresses.into_iter()
+        let results = result_addresses
+            .into_iter()
             .skip(offset)
             .take(limit)
             .collect::<Vec<_>>();
 
-        return Ok((results, count))
+        return Ok((results, count));
     }
 
     let mut approx_count = 0;
@@ -171,7 +184,7 @@ fn order_and_search<R: AsScore + tantivy::fastfield::FastValue>(
 
         for res in results {
             if past_addresses.contains(&res.1) {
-                continue
+                continue;
             }
 
             let addr = res.1;
@@ -184,7 +197,8 @@ fn order_and_search<R: AsScore + tantivy::fastfield::FastValue>(
         }
     }
 
-    let results = result_addresses.into_iter()
+    let results = result_addresses
+        .into_iter()
         .skip(offset)
         .take(limit)
         .collect::<Vec<_>>();
@@ -202,7 +216,8 @@ macro_rules! execute_staged_search {
                 .search_with_executor(&primary_stage, &collector, $executor)
                 .map_err(Error::from)?;
 
-            let results = results.into_iter()
+            let results = results
+                .into_iter()
                 .skip($offset)
                 .take($limit)
                 .collect::<Vec<_>>();
@@ -227,7 +242,7 @@ macro_rules! execute_staged_search {
 
                 for res in results {
                     if past_addresses.contains(&res.1) {
-                        continue
+                        continue;
                     }
 
                     let addr = res.1;
@@ -240,7 +255,8 @@ macro_rules! execute_staged_search {
                 }
             }
 
-            let results = result_addresses.into_iter()
+            let results = result_addresses
+                .into_iter()
                 .skip($offset)
                 .take($limit)
                 .collect::<Vec<_>>();
@@ -349,7 +365,9 @@ fn order_and_sort(
                     }
                 });
 
-            let out: (Vec<(Reverse<i64>, DocAddress)>, usize) = execute_staged_search!(queries, searcher, collector, executor, limit, offset)?;
+            let out: (Vec<(Reverse<i64>, DocAddress)>, usize) = execute_staged_search!(
+                queries, searcher, collector, executor, limit, offset
+            )?;
             (process_search(ctx, searcher, schema, out.0)?, out.1)
         },
         FieldType::U64(_) => {
@@ -366,7 +384,9 @@ fn order_and_sort(
                     }
                 });
 
-            let out: (Vec<(Reverse<u64>, DocAddress)>, usize) = execute_staged_search!(queries, searcher, collector, executor, limit, offset)?;
+            let out: (Vec<(Reverse<u64>, DocAddress)>, usize) = execute_staged_search!(
+                queries, searcher, collector, executor, limit, offset
+            )?;
             (process_search(ctx, searcher, schema, out.0)?, out.1)
         },
         FieldType::F64(_) => {
@@ -383,7 +403,9 @@ fn order_and_sort(
                     }
                 });
 
-            let out: (Vec<(Reverse<f64>, DocAddress)>, usize) = execute_staged_search!(queries, searcher, collector, executor, limit, offset)?;
+            let out: (Vec<(Reverse<f64>, DocAddress)>, usize) = execute_staged_search!(
+                queries, searcher, collector, executor, limit, offset
+            )?;
             (process_search(ctx, searcher, schema, out.0)?, out.1)
         },
         FieldType::Date(_) => {
@@ -400,7 +422,9 @@ fn order_and_sort(
                     }
                 });
 
-            let out: (Vec<(Reverse<DateTime>, DocAddress)>, usize) = execute_staged_search!(queries, searcher, collector, executor, limit, offset)?;
+            let out: (Vec<(Reverse<DateTime>, DocAddress)>, usize) = execute_staged_search!(
+                queries, searcher, collector, executor, limit, offset
+            )?;
             (process_search(ctx, searcher, schema, out.0)?, out.1)
         },
         _ => return Err(Error::msg("field is not a fast field")),
@@ -563,8 +587,13 @@ impl Reader {
                     )?
                 } else {
                     let collector = TopDocs::with_limit(limit);
-                    let out: (Vec<(Score, DocAddress)>, usize) = execute_staged_search!(queries, searcher, collector, executor, limit, offset)?;
-                    (process_search(ctx.as_ref(), &searcher, schema, out.0)?, out.1)
+                    let out: (Vec<(Score, DocAddress)>, usize) = execute_staged_search!(
+                        queries, searcher, collector, executor, limit, offset
+                    )?;
+                    (
+                        process_search(ctx.as_ref(), &searcher, schema, out.0)?,
+                        out.1,
+                    )
                 };
 
                 Ok::<_, Error>((hits, count))

--- a/lnx-server/Cargo.toml
+++ b/lnx-server/Cargo.toml
@@ -9,7 +9,7 @@ description = "The adaptable deployment of the tantivy search engine. Standing o
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["rt-multi-thread", "rt", "signal", "parking_lot"] }
+tokio = { version = "1", features = ["rt-multi-thread", "rt", "signal", "parking_lot", "macros"] }
 fern = { version = "0.6", features = ["colored"] }
 chrono = { version = "0.4", features = ["serde"] }
 hashbrown = { version = "0.11", features = ["serde"] }


### PR DESCRIPTION
This adds staggered searches. Allowing for greater performance boosts and better relevancy for the fuzzy search system.

Note that this does cause the `count` field to become an approximation rather than an accurate count when the fuzzy search is in play.

Closes #76 