### PR TITLE
Added an API function to get documents count in index.

### DIFF
--- a/lnx-engine/search-index/src/index.rs
+++ b/lnx-engine/search-index/src/index.rs
@@ -85,6 +85,11 @@ impl Index {
         self.0.clear_documents().await
     }
 
+    /// Gets count of searchable documents in the index.
+    pub async fn get_documents_count(&self) -> Result<usize> {
+        self.0.get_documents_count().await
+    }
+
     /// Adds a set of stop words to the indexes' stop word manager.
     ///
     /// This function is semi-asynchronous in the sense that there is a buffer of
@@ -229,6 +234,18 @@ impl InternalIndex {
     /// Deletes all documents from the index.
     async fn clear_documents(&self) -> Result<()> {
         self.writer.send_op(WriterOp::DeleteAll).await
+    }
+
+    /// Gets count of searchable documents in the index.
+    async fn get_documents_count(&self) -> Result<usize> {
+        if let Ok(metas) = self._ctx.index.searchable_segment_metas() {
+            let mut count = 0usize;
+            for m in metas {
+                count += m.num_docs() as usize;
+            }
+            return Ok(count);
+        }
+        Ok(0)
     }
 
     /// Deletes a specific document

--- a/lnx-server/src/routes/index.rs
+++ b/lnx-server/src/routes/index.rs
@@ -307,3 +307,15 @@ pub async fn clear_documents(req: LnxRequest) -> LnxResponse {
 
     json_response(200, "changes registered")
 }
+
+/// Gets count of searchable documents in the index.
+pub async fn get_documents_count(req: LnxRequest) -> LnxResponse {
+    let state = req.data::<State>().expect("get state");
+    let index = get_or_400!(req.param("index"));
+    let index: Index =
+        get_or_400!(state.engine.get_index(index), "index does not exist");
+
+    let count = index.get_documents_count().await?;
+
+    json_response(200, &format!("{}", count))
+}

--- a/lnx-server/src/routes/mod.rs
+++ b/lnx-server/src/routes/mod.rs
@@ -25,6 +25,7 @@ pub fn get_router(state: State) -> Router<Body, LnxError> {
         .post("/indexes/:index/search", index::search_index)
         .post("/indexes/:index/hint", index::get_corrected_query_hint)
         .post("/indexes/:index/documents", index::add_documents)
+        .get("/indexes/:index/documents/count", index::get_documents_count)
         .get("/indexes/:index/stopwords", index::get_stop_words)
         .post("/indexes/:index/stopwords", index::add_stop_words)
         .delete("/indexes/:index/stopwords", index::remove_stop_words)


### PR DESCRIPTION
There is no functionality to get current number of documents in the index. I've added one.