### PR TITLE
Add index stat endpoint to expose document count in a index

### DIFF
--- a/lnx-engine/search-index/src/structures.rs
+++ b/lnx-engine/search-index/src/structures.rs
@@ -882,15 +882,18 @@ impl DocumentHit {
 
 #[derive(Debug, Serialize)]
 pub struct IndexStats {
-    // The number of documents in the index.
-    pub docs: usize,
-    // The number of deleted documents in the index.
-    pub deleted_docs: usize,
+    /// The number of documents in the index.
+    pub num_docs: usize,
+    /// The number of deleted documents in the index.
+    pub num_deleted_docs: usize,
 }
 
 impl IndexStats {
-    pub fn new(docs: usize, deleted_docs: usize) -> Self {
-        Self { docs, deleted_docs }
+    pub fn new(num_docs: usize, num_deleted_docs: usize) -> Self {
+        Self {
+            num_docs,
+            num_deleted_docs,
+        }
     }
 }
 

--- a/lnx-engine/search-index/src/structures.rs
+++ b/lnx-engine/search-index/src/structures.rs
@@ -880,6 +880,20 @@ impl DocumentHit {
     }
 }
 
+#[derive(Debug, Serialize)]
+pub struct IndexStats {
+    // The number of documents in the index.
+    pub docs: usize,
+    // The number of deleted documents in the index.
+    pub deleted_docs: usize,
+}
+
+impl IndexStats {
+    pub fn new(docs: usize, deleted_docs: usize) -> Self {
+        Self { docs, deleted_docs }
+    }
+}
+
 mod document_id_serializer {
     use serde::Serializer;
 

--- a/lnx-server/src/routes/index.rs
+++ b/lnx-server/src/routes/index.rs
@@ -313,13 +313,7 @@ pub async fn get_index_stats(req: LnxRequest) -> LnxResponse {
     let index = get_or_400!(req.param("index"));
     let index: Index = get_or_400!(state.engine.get_index(index));
 
-    let stats = index.get_doc_count().await?;
+    let stats = index.get_doc_count()?;
 
-    json_response(
-        200,
-        &serde_json::json!({
-            "num_docs": stats.docs,
-            "num_deleted_docs": stats.deleted_docs,
-        }),
-    )
+    json_response(200, &stats)
 }

--- a/lnx-server/src/routes/index.rs
+++ b/lnx-server/src/routes/index.rs
@@ -307,3 +307,19 @@ pub async fn clear_documents(req: LnxRequest) -> LnxResponse {
 
     json_response(200, "changes registered")
 }
+
+pub async fn get_index_stats(req: LnxRequest) -> LnxResponse {
+    let state = req.data::<State>().expect("get state");
+    let index = get_or_400!(req.param("index"));
+    let index: Index = get_or_400!(state.engine.get_index(index));
+
+    let stats = index.get_doc_count().await?;
+
+    json_response(
+        200,
+        &serde_json::json!({
+            "num_docs": stats.docs,
+            "num_deleted_docs": stats.deleted_docs,
+        }),
+    )
+}

--- a/lnx-server/src/routes/mod.rs
+++ b/lnx-server/src/routes/mod.rs
@@ -47,6 +47,7 @@ pub fn get_router(state: State) -> Router<Body, LnxError> {
             "/indexes/:index/documents/:document_id",
             index::delete_document,
         )
+        .get("indexes/:index/stats", index::get_index_stats)
         .err_handler(default_handlers::error_handler)
         .any(default_handlers::handle_404)
         .build()


### PR DESCRIPTION
Address issue #13 by adding a endpoint to expose the number of searchable and deleted documents in a index by accessing [Tantivy index metadata](https://docs.rs/tantivy/latest/tantivy/struct.IndexMeta.html).
