### PR TITLE
Upgrade zip to 2.1.3 and fix the vulnerability in it's dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +489,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +513,17 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -673,7 +704,7 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -997,6 +1028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,7 +1139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -1633,7 +1670,7 @@ dependencies = [
  "sled",
  "sysinfo",
  "tantivy",
- "time 0.3.36",
+ "time",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1698,6 +1735,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simdutf8"
@@ -1850,7 +1893,7 @@ dependencies = [
  "tantivy-tokenizer-api",
  "tempfile",
  "thiserror",
- "time 0.3.36",
+ "time",
  "uuid",
  "winapi",
 ]
@@ -1890,7 +1933,7 @@ dependencies = [
  "byteorder",
  "ownedbytes",
  "serde",
- "time 0.3.36",
+ "time",
 ]
 
 [[package]]
@@ -2006,17 +2049,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -2258,12 +2290,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -2584,15 +2610,34 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.13"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+checksum = "775a2b471036342aa69bc5a602bc889cb0a06cda00477d0c69566757d5553d39"
 dependencies = [
- "byteorder",
+ "arbitrary",
  "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
  "flate2",
+ "indexmap 2.2.6",
+ "memchr",
  "thiserror",
- "time 0.1.45",
+ "time",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/lnx-server/Cargo.toml
+++ b/lnx-server/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 hyper = { version = "0.14", features = ["server", "http1", "http2"] }
 sled = { version = "0.34.7" }
 clap = { version = "3", features = ["derive", "env"] }
-zip = { version = "0.5.13", default-features = false, features = ["time", "deflate"] }
+zip = { version = "2.1.3", default-features = false, features = ["time", "deflate"] }
 
 walkdir = "2.3.2"
 thiserror = "1.0.30"

--- a/lnx-server/src/snapshot.rs
+++ b/lnx-server/src/snapshot.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 use engine::structures::ROOT_PATH;
 use walkdir::{DirEntry, WalkDir};
 use zip::read::ZipArchive;
-use zip::write::FileOptions;
+use zip::write::{FileOptions, SimpleFileOptions};
 use zip::CompressionMethod;
 
 static IGNORE_FILES: [&str; 1] = [".tantivy-writer.lock"];
@@ -132,7 +132,7 @@ fn zip_dir(
     prefix: &Path,
     writer: File,
 ) -> zip::result::ZipResult<()> {
-    let options;
+    let options: SimpleFileOptions;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -165,7 +165,7 @@ fn zip_dir(
             }
 
             info!("adding file {:?} as {:?} ...", path, name);
-            zip.start_file(path_to_string(path), options)?;
+            zip.start_file(path_to_string(path), options.clone())?;
             let mut f = File::open(path)?;
 
             f.read_to_end(&mut buffer)?;
@@ -173,7 +173,7 @@ fn zip_dir(
             buffer.clear();
         } else if !name.as_os_str().is_empty() {
             info!("adding dir {:?} as {:?} ...", path, name);
-            zip.add_directory(path_to_string(path), options)?;
+            zip.add_directory(path_to_string(path), options.clone())?;
         }
     }
     zip.finish()?;


### PR DESCRIPTION
The dependency zip 0.5.13 depends on a crate with vulnerability. This PR upgrades it and makes necessary changes according to the new interface.

```
Crate:     time
Version:   0.1.45
Title:     Potential segfault in the time crate
Date:      2020-11-18
ID:        RUSTSEC-2020-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0071
Severity:  6.2 (medium)
Solution:  Upgrade to >=0.2.23
Dependency tree:
time 0.1.45
└── zip 0.5.13
    └── lnx 0.9.0
```