### PR TITLE
Fix mismatch of unites in memory size returned in sysinfo

### DIFF
--- a/lnx-engine/search-index/src/writer.rs
+++ b/lnx-engine/search-index/src/writer.rs
@@ -1,3 +1,4 @@
+use std::cmp::max;
 use std::collections::HashMap;
 use std::mem;
 use std::path::Path;
@@ -106,13 +107,13 @@ impl WriterContext {
                 info!(
                     "target buffer size of {}KB cannot be reached due \
                     to not enough free memory, defaulting to {}KB",
-                    target_buffer_size,
+                    target_buffer_size / 1_000,
                     buffer / 1_000,
                 );
 
-                buffer = min_buffer;
+                buffer = max(free_mem as usize, min_buffer);
             } else {
-                buffer = (target_buffer_size * 1_000) as usize;
+                buffer = (target_buffer_size) as usize;
             }
         }
 
@@ -122,11 +123,11 @@ impl WriterContext {
         }
 
         let free_mem = sys.free_memory();
-        if buffer > (free_mem * 1000) as usize {
+        if buffer > free_mem as usize {
             return Err(Error::msg(format!(
                 "cannot allocate {}KB due to system not having enough free memory. (Free: {}KB)",
                 buffer / 1_000,
-                free_mem
+                free_mem / 1_000
             )));
         }
 


### PR DESCRIPTION
The memory size returned in sysinfo is in bytes but was accidentally treated as KB previously.

```rust
    /// Returns the RAM size in bytes.
    ///
    /// ```no_run
    /// use sysinfo::System;
    ///
    /// let s = System::new_all();
    /// println!("{} bytes", s.total_memory());
    /// ```
    ///
    /// On Linux, if you want to see this information with the limit of your cgroup, take a look
    /// at [`cgroup_limits`](System::cgroup_limits).
    pub fn total_memory(&self) -> u64 {
        self.inner.total_memory()
    }

    /// Returns the amount of free RAM in bytes.
    ///
    /// Generally, "free" memory refers to unallocated memory whereas "available" memory refers to
    /// memory that is available for (re)use.
    ///
    /// Side note: Windows doesn't report "free" memory so this method returns the same value
    /// as [`available_memory`](System::available_memory).
    ///
    /// ```no_run
    /// use sysinfo::System;
    ///
    /// let s = System::new_all();
    /// println!("{} bytes", s.free_memory());
    /// ```
    pub fn free_memory(&self) -> u64 {
        self.inner.free_memory()
    }
```